### PR TITLE
Separate Query and Article Stores

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,7 +5,7 @@
   },
   "env":{
     "NODE_ENV": "production",
-    "USE_MEMORY_STORE": true,
+    "USE_MEMORY_STORE": "true",
     "HEROKU_APP_NAME": {
       "required": true
     },

--- a/src/server/api-routes.js
+++ b/src/server/api-routes.js
@@ -20,7 +20,7 @@ function category(req, res, next) {
     case 'articles':
       const query = {
         uuid: req.params.uuid,
-        dateFrom: req.body.dateFrom || moment().add(-2, 'weeks').toISOString(),
+        dateFrom: req.body.dateFrom || moment().add(-1, 'weeks').toISOString(),
         dateTo: req.body.dateTo || moment().toISOString()
       };
       esClient(req.params.category, query)

--- a/src/server/dataPreloader.js
+++ b/src/server/dataPreloader.js
@@ -2,24 +2,37 @@ import express from 'express';
 import request from "superagent";
 import dataApiUtils from '../shared/utils/DataAPIUtils';
 
+import moment from 'moment';
+
 let router = express.Router();
 let apiKey = process.env.LANTERN_API_KEY;
 
 router.get('/articles/:uuid', (req, res, next) => {
 
-    dataApiUtils.getArticleData({uuid: req.params.uuid}, apiKey)
-        .then((data) => {
-            res.locals.data = {
-                "ArticleStore": {
-                    data: data
-                }
-            };
-            next();
-        })
-        .catch((err) => {
-            next(new Error(err));
-        })
+  let query = {
+    uuid: req.params.uuid,
+    datefrom: moment().add(-7, 'days').toISOString(), // XXX make this a default sensible range
+    dateTo: moment().toISOString(),
+    comparator: null,
+    filters: []
+  }
+
+
+  dataApiUtils.getArticleData(query, apiKey)
+      .then((data) => {
+          res.locals.data = {
+              "ArticleStore": {
+                data: data
+              },
+              "QueryStore" : {
+                query: query
+              }
+          };
+          next();
+      })
+      .catch((err) => {
+          next(new Error(err));
+      });
 });
 
 export default router;
-

--- a/src/shared/actions/ArticleActions.js
+++ b/src/shared/actions/ArticleActions.js
@@ -1,18 +1,26 @@
 import alt from '../alt';
 
+
+
 class ArticleActions {
-    constructor() {
-        this.generateActions(
-            'addFilter',
-            'removeFilter',
-            'selectComparator',
-            'selectDateRange',
-            'requestData',
-            'receiveData',
-            'receiveDataFailed',
-            'destroy'
-        )
-    }
+  constructor() {
+
+  }
+
+  updateData(data) {
+    this.dispatch(data);
+  }
+
+  loadingData() {
+    setImmediate(()=> {
+      this.dispatch();
+    });
+  }
+
+  loadingFailed(error) {
+    this.dispatch(error);
+  }
+
 }
 
 export default alt.createActions(ArticleActions);

--- a/src/shared/actions/QueryActions.js
+++ b/src/shared/actions/QueryActions.js
@@ -1,0 +1,15 @@
+import alt from '../alt';
+
+class QueryActions {
+  constructor() {
+    this.generateActions(
+        'addFilter',
+        'removeFilter',
+        'selectComparator',
+        'selectDateRange',
+        'selectUUID'
+    );
+  }
+}
+
+export default alt.createActions(QueryActions);

--- a/src/shared/components/Modifier.js
+++ b/src/shared/components/Modifier.js
@@ -5,14 +5,6 @@ import Comparator from "./Comparator";
 import Filters from "./Filters";
 import DateRange from "./DateRange";
 
-const tags = [
-  "FT.com",
-  "UK",
-  "Business & Economy",
-  "Transport for London",
-  "Tanys Powley"
-];
-
 export default class Modifier extends React.Component {
 
   constructor(props) {
@@ -20,7 +12,6 @@ export default class Modifier extends React.Component {
   }
 
   render() {
-
     return (
       <div>
         <Comparator tags={this.props.tags} />

--- a/src/shared/components/SingleMetric.js
+++ b/src/shared/components/SingleMetric.js
@@ -136,20 +136,20 @@ export default class SingleMetric extends React.Component {
 
     // Do the correct metric conversions
     if (this.props.metricType === 'integer') {
-      metricValues = integerMetricConversions(this.props)
+      metricValues = integerMetricConversions(this.props);
     }
     else if (this.props.metricType === 'time') {
-      metricValues = timeMetricConversions(this.props)
+      metricValues = timeMetricConversions(this.props);
     }
 
     //If there is no comparator leave the comparator HTML undefined
     if (typeof metricValues.transfromComparator !== 'undefined') {
-      comparatorHTML = [
+      comparatorHTML = (
         <span style={styles.comparator}>
           <Glyphicon glyph={'glyphicon glyphicon-chevron-' + metricValues.differenceSign} style={styles.comparatorSymbol} />
           <span style={styles.comparatorValue}>{metricValues.transfromComparator}</span>
         </span>
-      ]
+      );
     }
 
     return (
@@ -157,7 +157,7 @@ export default class SingleMetric extends React.Component {
         <p style={styles.metric}>{metricValues.transformMetric} {comparatorHTML}</p>
         <h3 style={styles.label}>{this.props.label}</h3>
       </div>
-    )
+    );
   }
 }
 

--- a/src/shared/handlers/Article.js
+++ b/src/shared/handlers/Article.js
@@ -6,10 +6,12 @@ import Header from "../components/Header";
 import { Col, Row } from 'react-bootstrap';
 import Modifier from "../components/Modifier";
 import LineChart from "../components/LineChart";
+import Loading from "../components/Loading";
 
 import SingleMetric from "../components/SingleMetric";
 import ArticleStore from '../stores/ArticleStore';
-import ArticleActions from '../actions/ArticleActions';
+import QueryStore from '../stores/QueryStore';
+import QueryActions from '../actions/QueryActions';
 
 const style = {
   'margin': '10px 0',
@@ -24,70 +26,101 @@ class ArticleView extends React.Component {
   }
 
   static getStores() {
-    return [ArticleStore];
+    return [ArticleStore, QueryStore];
   }
 
   static getPropsFromStores() {
-    let state = ArticleStore.getState();
-    return state;
+    let articleState = ArticleStore.getState();
+    let queryState = QueryStore.getState();
+    return {
+      query : queryState.query,
+      data : articleState.data,
+      loading : articleState.loading,
+      errorMessage : articleState.errorMessage
+    };
   }
 
   componentWillMount() {
-    ArticleActions.requestData(this.props.params.id);
+    // XXX consider putting this inside ArticleStore?
+    this._boundQueryHandlerRef = this._handleQueryChange.bind(this);
+    QueryStore.listen(this._boundQueryHandlerRef);
+    if (this.props.params.id !== this.props.query.uuid) {
+      QueryActions.selectUUID(this.props.params.id);
+    }
+    // ArticleStore.loadArticleData(this.props.query);
   }
 
   componentWillUnmount() {
-    ArticleActions.destroy();
+    QueryStore.unlisten(this._boundQueryHandlerRef);
+  }
+
+  _handleQueryChange() {
+    ArticleStore.loadArticleData(this.props.query);
   }
 
   render() {
     let data = this.props.data;
+
+    if (!data || this.props.loading) {
+
+      const loadingStyle = {
+        height: '100%',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center'
+      };
+
+      return (<div style={loadingStyle}><Loading /></div>);
+    }
 
     let title = (data) ? 'Lantern - ' + data.article.title : '';
     return (<DocumentTitle title={title}>
       <div>
         <Row style={style}>
           <Header
-              title={data ? data.article.title : 'loading'}
-              author={data ? 'By: ' + data.article.author : 'loading'}
-              published={data ? 'Published: ' + data.article.published_human : 'loading'}
+              title={data.article.title}
+              author={'By: ' + data.article.author}
+              published={'Published: ' + data.article.published_human}
               />
         </Row>
         <Row  style={style}>
-          <Modifier tags={data ? data.article.topics.concat(data.article.sections) : []}/>
+          <Modifier
+            tags={data.article.topics.concat(data.article.sections)}
+            query={this.props.query}
+            />
         </Row>
         <main>
           <Row >
             <Col xs={12} sm={3} >
               <Col xs={4} sm={12} >
-                <SingleMetric metric={data ? data.article.wordCount : 0} metricType='integer' label='Article Wordcount' size='small' />
+                <SingleMetric metric={data.article.wordCount} metricType='integer' label='Article Wordcount' size='small' />
               </Col>
               <Col xs={4} sm={12} >
-                <SingleMetric metric={data ? data.article.imageCount : 0} metricType='integer' label='Images' size='small' />
+                <SingleMetric metric={data.article.imageCount} metricType='integer' label='Images' size='small' />
               </Col>
               <Col xs={4} sm={12} >
-                <SingleMetric metric={data ? data.article.bodyLinksCount : 0} metricType='integer' label='Body Links' size='small' />
+                <SingleMetric metric={data.article.bodyLinksCount} metricType='integer' label='Body Links' size='small' />
               </Col>
             </Col>
             <Col xs={12} sm={9} >
               <Col xs={12} sm={4} >
-                <SingleMetric metric={data ? data.article.timeOnPage : 0} comparatorMetric={2} metricType='time' label='Time on Page' size='large' />
+                <SingleMetric metric={data.article.timeOnPage} comparatorMetric={2} metricType='time' label='Time on Page' size='large' />
               </Col>
               <Col xs={12} sm={4} >
-                <SingleMetric metric={data ? data.article.pageViews : 0} comparatorMetric={8092} metricType='integer' label='Page Views' size='large' />
+                <SingleMetric metric={data.article.pageViews} comparatorMetric={8092} metricType='integer' label='Page Views' size='large' />
               </Col>
               <Col xs={12} sm={4} >
-                <SingleMetric metric={data ? data.article.socialReaders : 0} comparatorMetric={808} metricType='integer' label='Social Readers' size='large' />
+                <SingleMetric metric={data.article.socialReaders} comparatorMetric={808} metricType='integer' label='Social Readers' size='large' />
               </Col>
             </Col>
           </Row>
           <LineChart
-            data={data ? data.article.readTimes : []}
+            data={data.article.readTimes}
             keys={['value']}
             title="When did readers access the article?"/>
           <Row>
             <Col lg={12} >
-              <div>id: {data ? data.article.uuid : 'loading'}</div>
+              <div>id: {data.article.uuid}</div>
             </Col>
           </Row>
         </main>

--- a/src/shared/handlers/ArticleList.js
+++ b/src/shared/handlers/ArticleList.js
@@ -11,6 +11,7 @@ class ArticleList extends React.Component {
       <div>
         <h2>Articles List</h2>
         <div><Link to="/articles/0049a468-4be5-11e5-b558-8a9722977189">Private equity secondaries evolve with Palamon deal</Link></div>
+        <div><Link to="/articles/200bcb86-4bb9-11e5-9b5d-89a026fda5c9">Uber: Chinese traffic jam</Link></div>
       </div>
     </DocumentTitle>);
   }

--- a/src/shared/sources/ArticleSource.js
+++ b/src/shared/sources/ArticleSource.js
@@ -1,0 +1,22 @@
+import DataAPI from '../utils/DataAPIUtils';
+import ArticleActions from '../actions/ArticleActions';
+
+let ArticleSource = {
+  loadArticleData: {
+    remote(state, query) {
+      return DataAPI.getArticleData(query);
+    },
+    local() {
+      return null;
+    },
+    success: ArticleActions.updateData,
+    error: ArticleActions.loadingFailed,
+    loading: ArticleActions.loadingData,
+
+    shouldFetch(query) {
+      return true;
+    }
+  }
+};
+
+export default ArticleSource;

--- a/src/shared/stores/ArticleStore.js
+++ b/src/shared/stores/ArticleStore.js
@@ -3,60 +3,42 @@ import assign from 'object-assign';
 import _ from 'underscore';
 
 import ArticleActions from '../actions/ArticleActions';
-import DataAPI from '../utils/DataAPIUtils';
+import ArticleSource from '../sources/ArticleSource';
 
-let query = {
-    uuid: null,
-    dateFrom: null,
-    dateTo: null,
-    comparator: null,
-    filters: []
-};
+import QueryStore from '../stores/QueryStore';
 
 class ArticleStore {
 
-    constructor() {
-        this.bindActions(ArticleActions);
-        this.data = null;
-        this.errorMessage = null;
-    }
+  constructor() {
+    this.data = null;
+    this.errorMessage = null;
+    this.loading = false;
+    this.bindListeners({
+      handleUpdateData: ArticleActions.UPDATE_DATA,
+      handleLoadingData: ArticleActions.LOADING_DATA,
+      handleLoadingFailed: ArticleActions.LOADING_FAILED
+    });
 
-    update(param, updates) {
-        if(query[param] && updates){
-            query[param] = assign(query[param], updates);
-        }
-    }
+    this.exportAsync(ArticleSource);
 
-    receiveData(newData) {
-        this.data = newData;
-        this.errorMessage = null;
-    }
+  }
 
-    receiveDataFailed(errorMessage) {
-        this.errorMessage = errorMessage;
-    }
-    requestData(id) {
-        query.uuid = id;
-        DataAPI.getArticleData(query)
-            .then(function(data) {
-                ArticleActions.receiveData(data);
-            }).catch(function () {
-               alert('whoah!');
-            });
-    }
+  handleLoadingData() {
+    this.loading = true;
+    this.data = null;
+  }
 
-    addFilter(filter) {
-        this.update('filters', _.union(query.filters, [filter]));
-    }
-    removeFilter(filter) {
-        this.update('filters', _.without(query.filters, [filter]));
-    }
-    selectComparator(comparator) {
-        this.update('comparator', comparator);
-    }
-    destroy() {
-        alt.recycle(this);
-    }
+  handleUpdateData(newData) {
+    this.loading = false;
+    this.data = newData;
+    this.errorMessage = null;
+  }
+
+  handleLoadingFailed(errorMessage) {
+    this.loading = false;
+    this.errorMessage = errorMessage;
+  }
+
 
 }
 

--- a/src/shared/stores/QueryStore.js
+++ b/src/shared/stores/QueryStore.js
@@ -1,0 +1,49 @@
+import alt from '../alt';
+import assign from 'object-assign';
+import _ from 'underscore';
+
+
+import QueryActions from '../actions/QueryActions';
+
+class QueryStore {
+
+  constructor() {
+    this.bindActions(QueryActions);
+    this.query = {
+        uuid: null,
+        datefrom: null, // XXX make this a default sensible range
+        dateTo: null,
+        comparator: null,
+        filters: []
+    };
+  }
+
+  _update(param, updates) {
+    if(this.query[param] && updates){
+      this.query[param] = assign(this.query[param], updates);
+    }
+  }
+
+  addFilter(filter) {
+    this._update('filters', _.union(query.filters, [filter]));
+  }
+  removeFilter(filter) {
+    this._update('filters', _.without(query.filters, [filter]));
+  }
+
+  selectDateRange(dates) {
+    this.query.dateFrom = dates.from;
+    this.query.dateTo = dates.to;
+  }
+
+  selectUUID(uuid) {
+    this.query.uuid = uuid;
+  }
+
+  selectComparator(comparatorId) {
+    this.query.comparator = comparatorId;
+  }
+
+}
+
+export default alt.createStore(QueryStore, 'QueryStore');

--- a/src/shared/utils/DataAPIUtils.js
+++ b/src/shared/utils/DataAPIUtils.js
@@ -5,7 +5,6 @@ import config from "../config";
 let DataAPI = {
 
     getArticleData(query, apiKey) {
-
         return new Promise(function (resolve, reject) {
             let url = config.baseUrl + '/api/v0/articles/' + query.uuid;
             if (apiKey) {


### PR DESCRIPTION
Query and Article stores are now separate entities. This will allow us to keep the stores simple and focused. The `ArticleStore` deals with loading data and informing listeners about the load progress. The `QueryStore` handles modifying the search settings for the query, to which the Article responds accordingly, orchestrated through the `ArticleHandler` view, who sets up listeners for query changes and decides when to pass those to ArticleStore.

All in all, cleaner architecture on the data / flux side.