### PR TITLE
cache buster

### DIFF
--- a/src/server/server.js
+++ b/src/server/server.js
@@ -12,8 +12,10 @@ import errorRoutes from "../shared/routers/error";
 import dataPreloader from "./routers/dataPreloader-routes";
 import apiRouter from "./routers/api-routes";
 import authRouter from "./routers/auth-routes";
+import uuid from 'uuid';
 
 delete process.env.BROWSER;
+let cacheBustId = uuid();
 const app = express();
 const hbs = exphbs.create({});
 
@@ -58,7 +60,12 @@ function renderRoute(route, req, res) {
     }
     let content = React.renderToString(<Handler />);
     iso.add(content, alt.flush());
-    res.render('index', { content: iso.render(), jsUrl: config.jsUrl, title: DocumentTitle.rewind() });
+    res.render('index',
+      { content: iso.render(),
+        jsUrl: config.jsUrl,
+        version: '?v=' + cacheBustId,
+        title: DocumentTitle.rewind()
+      });
 
   });
 }

--- a/src/server/views/index.hbs
+++ b/src/server/views/index.hbs
@@ -35,6 +35,6 @@
     <div id="react-app">
         {{{content}}}
     </div>
-    <script src="{{jsUrl}}/js/app.js" defer></script>
+    <script src="{{jsUrl}}/js/app.js{{version}}" defer></script>
   </body>
 </html>


### PR DESCRIPTION
Add versioning to app.js on index.hbs so that the server doesn't cache old files - might sort out the issue with cache on the lantern.ft.com server

![giphy 6](https://cloud.githubusercontent.com/assets/780409/9813429/4e9b438e-587d-11e5-89aa-f43b63e6a64e.gif)
