### PR TITLE
Stop one potential source of 404 flashes

### DIFF
--- a/src/shared/actions/ArticleActions.js
+++ b/src/shared/actions/ArticleActions.js
@@ -11,9 +11,7 @@ class ArticleActions {
   }
 
   loadingData() {
-    setImmediate(()=> {
-      this.dispatch();
-    });
+    setImmediate(_ => this.dispatch());
   }
 
 }

--- a/src/shared/handlers/Article.js
+++ b/src/shared/handlers/Article.js
@@ -44,21 +44,6 @@ class ArticleView extends React.Component {
     };
   }
 
-  componentWillMount() {
-    // XXX consider putting this inside ArticleStore?
-    this._boundQueryHandlerRef = this._handleQueryChange.bind(this);
-    QueryStore.listen(this._boundQueryHandlerRef);
-
-    if (this.props.data) {
-      return;
-    }
-
-    QueryActions.selectUUID(this.props.params.uuid);
-    if (this.props.params.comparator){
-      QueryActions.selectComparator(this.props.params.comparator);
-    }
-  }
-
   componentWillUnmount() {
     QueryStore.unlisten(this._boundQueryHandlerRef);
     ArticleActions.destroy();
@@ -77,18 +62,32 @@ class ArticleView extends React.Component {
     let analytics = require('../utils/analytics');
     analytics.sendGAEvent('pageview');
     analytics.trackScroll();
+
+    // XXX consider putting this inside ArticleStore?
+    this._boundQueryHandlerRef = this._handleQueryChange.bind(this);
+    QueryStore.listen(this._boundQueryHandlerRef);
+
+    if (this.props.data) {
+      return;
+    }
+
+    QueryActions.selectUUID(this.props.params.uuid);
+    if (this.props.params.comparator){
+      QueryActions.selectComparator(this.props.params.comparator);
+    }
+
   }
 
   render() {
-    if (this.props.errorMessage) {
+    if (this.props.errorMessage && !this.props.loading) {
       return (<div><Error404/></div>);
     }
 
     let data = this.props.data;
-    let hasComparator = this.props.params.comparator !== undefined ? true : false;
+    let hasComparator = (this.props.params.comparator !== undefined);
     let comparatorData = this.props.comparatorData;
 
-    if (!data || this.props.loading || comparatorData == null && this.props.params.comparator !== undefined) {
+    if (!data || this.props.loading || comparatorData == null && hasComparator) {
 
       const loadingStyle = {
         display: 'flex',
@@ -96,7 +95,11 @@ class ArticleView extends React.Component {
         justifyContent: 'center'
       };
 
-      return (<div style={loadingStyle}><Logo message="Loading Article..." loading /></div>);
+      return (
+        <div style={loadingStyle}>
+          <Logo message="Loading Article..." loading />
+        </div>
+      );
     }
 
     let title = (data) ? 'Lantern - ' + data.article.title : '';

--- a/src/shared/stores/ArticleStore.js
+++ b/src/shared/stores/ArticleStore.js
@@ -37,7 +37,6 @@ class ArticleStore {
   handleLoadingFailed(error) {
     this.loading = false;
     this.errorMessage = error.message;
-  
     Raven.captureException(error, {
       extra: error
     });


### PR DESCRIPTION
the query change listeners were being setup in the backend, which was triggering a 401, since the app was unauthorised at that point (the request was being done without the appropriate credentials). This was causing the `ArticleStore` to in turn be populated with an `errorMessage` of `Unauthorized`. This message was cleared once a call to load data was triggered, but since `loadingData` is called with `setInmmediate`, the change wasn't happening in the same event loop, and thus react would render for a state where `errorMessage` was set. 

Since it is not necessary for the backend to subscribe to query changes, we do this on `componentDidMount` - thus avoiding "fake" requests.

also cleaned up some of the logic on the `render` function of the article handler