### PR TITLE
Search Improvements

### DIFF
--- a/src/server/queries/Search.js
+++ b/src/server/queries/Search.js
@@ -9,9 +9,28 @@ export default function SearchQuery(query) {
     "argument 'query' must contain a 'term' property of type string");
 
   return {
-    "query" : {
-      "match" : {
-          "title": query.term
+    query : {
+      bool : {
+        must : {
+          match : {
+            title: query.term
+          }
+        },
+        should : [
+          {
+            match : {
+              title : {
+                query : query.term,
+                operator : "and"
+              }
+            }
+          },
+          {
+            match_phrase : {
+              title: query.term
+            }
+          }
+        ]
       }
     }
   };

--- a/src/shared/components/Search.js
+++ b/src/shared/components/Search.js
@@ -7,6 +7,8 @@ import Logo from '../components/Logo';
 
 import _ from 'underscore';
 
+const MIN_SEARCH_LENGTH = 2;
+
 export default class Search extends React.Component {
 
   constructor(props) {
@@ -19,7 +21,7 @@ export default class Search extends React.Component {
 
   showSearchResults(){
     const val = (this.refs && this.refs.searchinput) ? this.refs.searchinput.getValue() : '';
-    return val.length >= 3;
+    return val.length >= MIN_SEARCH_LENGTH;
   }
 
   componentDidMount() {


### PR DESCRIPTION
Added a mixed `bool` ES query, where we combine a `should` AND query and a `must` or query. This means that results that contain *all* of the terms will be ranked higher than results that contain less than all of the terms (prioritising exact matches). 

This actually makes very little difference compared to the standard behaviour, as matches of OR queries where all of the terms appear will still be ranked higher.

One alternative would be to add a further `match_phrase` query as an `should` clause of the main `bool` query, which requires terms to appear in order (i.e. 'shell abandons arctic' would match that, but 'arctic abandons shell' would not). This would further encourage exact text matches.

Also changed the minimum search term length to 2 chars