### PR TITLE
use pattern matching for choosing the index wildcard string

### DIFF
--- a/src/server/esClient.js
+++ b/src/server/esClient.js
@@ -5,9 +5,7 @@ import SearchQuery from './queries/Search';
 import assert from 'assert';
 import LoggerFactory from './logger';
 import moment from 'moment';
-
-const EARLIEST_INDEX = '2015-09-07'
-const EARLIEST_INDEX_FORMAT = 'YYYY-MM-DD'
+import calculateIndices from './utils/calculateIndices.js';
 
 var client = elasticsearch.Client({
   host: [
@@ -133,18 +131,4 @@ function retrieveMetaData(queryData){
 }
 
 
-function calculateIndices(query) {
-  let dateFrom = moment(moment(query.dateFrom).format(EARLIEST_INDEX_FORMAT));
-  let dateTo = moment(moment(query.dateTo).format(EARLIEST_INDEX_FORMAT));
-  const indexPrefix = process.env.ES_INDEX_ROOT;
-  let indices = [];
-  if (moment(EARLIEST_INDEX).isAfter(dateFrom, 'day')){
-    dateFrom = moment(moment(EARLIEST_INDEX).format(EARLIEST_INDEX_FORMAT));
-  }
-  while (dateFrom < dateTo){
-    indices.push(indexPrefix + dateFrom.format(EARLIEST_INDEX_FORMAT));
-    dateFrom.add(1, 'days');
-  }
 
-  return indices;
-}

--- a/src/server/utils/calculateIndices.js
+++ b/src/server/utils/calculateIndices.js
@@ -1,0 +1,27 @@
+import moment from 'moment';
+
+const INDEX_FORMAT = 'YYYY-MM-DD';
+
+export default function calculateIndices(query) {
+  let dateFrom = moment(moment(query.dateFrom)).format(INDEX_FORMAT);
+  let dateTo = moment(moment(query.dateTo)).format(INDEX_FORMAT);
+
+  let indexStr = '';
+
+  let charF, charT;
+  let i = 0;
+  while (i < dateFrom.length) {
+    charF = dateFrom[i];
+    charT = dateTo[i];
+
+    if (charF === charT) {
+      indexStr += charF;
+    } else {
+      indexStr += '*';
+      break;
+    }
+    i++;
+  }
+
+  return process.env.ES_INDEX_ROOT + indexStr;
+}

--- a/test/utils/calculateIndices.spec.js
+++ b/test/utils/calculateIndices.spec.js
@@ -1,0 +1,47 @@
+import {expect} from 'chai';
+import calculateIndices from '../../src/server/utils/calculateIndices';
+
+const ES_INDEX = 'indexName-';
+
+let oldEnv = process.env.ES_INDEX_ROOT;
+
+describe('#calculateIndices', () => {
+
+  beforeEach(()=> {
+    process.env.ES_INDEX_ROOT = ES_INDEX;
+  });
+
+  afterEach(() => {
+    process.env.ES_INDEX_ROOT = oldEnv;
+  });
+
+  it('should calculate the indices correctly for dates within the same ten days', () => {
+    const query = {
+      dateFrom: '2015-10-01',
+      dateTo: '2015-10-09'
+    };
+    const expected = ES_INDEX + '2015-10-0*';
+
+    expect(calculateIndices(query)).to.equal(expected);
+
+  });
+
+  it('should calculate the indices correclty for dates within the same month', () => {
+    const queries = [
+      {
+        dateFrom: '2015-10-01',
+        dateTo: '2015-10-10'
+      },
+      {
+        dateFrom: '2015-10-10',
+        dateTo: '2015-10-21'
+      }
+    ];
+    const expected = ES_INDEX + '2015-10-*';
+
+    for (let i = 0; i < queries.length; i++) {
+      expect(calculateIndices(queries[i])).to.equal(expected);
+    }
+  })
+
+});


### PR DESCRIPTION
Naively choosing *all* of the indices for a range of dates was making request URI's that were too long (413) so instead we now use just one string, with a `*` at the end to match all indices with a prefix.

that means if we have a query with a date range from `2015-01-20` and `2015-02-10`, we will come up with a string such as `indexName-2015-0*` which will match all the required indices. 

While this will match other indices, there is no apparent performance hit. If in the future we need to be more specific about the indices we pick, we can refine the algorithm to be more specific (i.e. having `indexName-2015-01-*,indexName-2015-02-*`)