### PR TITLE
fix bug when loading fresh url with a `:comparator`

### DIFF
--- a/src/server/esClient.js
+++ b/src/server/esClient.js
@@ -95,8 +95,6 @@ function retrievePageView(queryData){
       search_type: 'count',
       body: queryObject
     };
-    //todo: fix request.index when array gets too large
-    //either send smaller array or send as part of body
     client.search(request, (error, response) => {
       if (error) {
         return reject(error);


### PR DESCRIPTION
ensure loading a url with comparator in it doesn't break the site by pre-loading the data with correctly chosen dates