### PR TITLE
Referrer URL Table

### DIFF
--- a/src/server/formatters/Articles.js
+++ b/src/server/formatters/Articles.js
@@ -41,8 +41,9 @@ export default function formatData(data) {
           sections: metaData.sections,
           topics: metaData.topics,
           channels: formatTermsAggregation('channels', articleData),
-          referrer_types: formatTermsAggregation('referrer_types', articleData),
-          referrer_names: formatTermsAggregation('referrer_names', articleData),
+          referrer_types: formatFilteredTermsAggregation('referrer_types', articleData),
+          referrer_names: formatFilteredTermsAggregation('referrer_names', articleData),
+          referrer_urls: formatFilteredTermsAggregation('referrer_urls', articleData),
           devices : formatTermsAggregation('devices', articleData)
         }
       };
@@ -90,6 +91,16 @@ function formatTimeSeries(data) {
 
 function formatTermsAggregation(name, data) {
   let buckets = data.aggregations[name].buckets;
+  return buckets.map((d, i) => {
+    return [
+      d.key,
+      d.doc_count
+    ];
+  });
+}
+
+function formatFilteredTermsAggregation(name, data) {
+  let buckets = data.aggregations[name].filtered.buckets;
   return buckets.map((d, i) => {
     return [
       d.key,

--- a/src/server/queries/Articles.js
+++ b/src/server/queries/Articles.js
@@ -52,13 +52,51 @@ export default function PageViewsQuery(query) {
         }
       },
       referrer_types : {
-        terms: {
-          field: "referrer_type"
+        filter: {
+          not : {
+            term : {
+              referrer_type: "internal"
+            }
+          }
+        },
+        aggs: {
+          filtered : {
+            terms: {
+              field: "referrer_type"
+            }
+          }
         }
       },
       referrer_names : {
-        terms: {
-          field: "referrer_name"
+        filter: {
+          not : {
+            term : {
+              referrer_type: "internal"
+            }
+          }
+        },
+        aggs: {
+          filtered : {
+            terms: {
+              field: "referrer_name"
+            }
+          }
+        }
+      },
+      referrer_urls : {
+        filter: {
+          not : {
+            term : {
+              referrer_type: "internal"
+            }
+          }
+        },
+        aggs: {
+          filtered : {
+            terms: {
+              field: "referrer"
+            }
+          }
         }
       },
       devices : {

--- a/src/shared/components/Table.js
+++ b/src/shared/components/Table.js
@@ -31,7 +31,7 @@ export default class DataTable extends React.Component {
 
 
     return (
-      <Table responsive>
+      <Table >
         <thead>
           {heads}
         </thead>

--- a/src/shared/handlers/Article.js
+++ b/src/shared/handlers/Article.js
@@ -234,6 +234,24 @@ class ArticleView extends React.Component {
         views: d[1]
       };
     });
+
+    let refUrls = data.article.referrer_urls.map((d, i) => {
+      const maxLen = 60;
+      const displayString = d[0].length > maxLen ? d[0].substr(0, maxLen)+'…' : d[0];
+      let url = (
+        <a
+          target="_blank"
+          href={d[0]}
+          >
+          {displayString}
+        </a>
+      );
+      return {
+        referrer: d[0] ? url : 'Not available',
+        views: d[1]
+      };
+    });
+
     let externalReferrersComponent = (
       <div>
         <Row>
@@ -254,7 +272,7 @@ class ArticleView extends React.Component {
           <Col xs={12} sm={6}>
             <Table
               headers={['Referrer', 'Views']}
-              rows={refs}
+              rows={refUrls}
             />
           </Col>
         </Row>

--- a/test/fixtures/data/article_results.js
+++ b/test/fixtures/data/article_results.js
@@ -1,5 +1,5 @@
 export default [{
-  "took": 7,
+  "took": 41,
   "timed_out": false,
   "_shards": {
     "total": 25,
@@ -7,50 +7,45 @@ export default [{
     "failed": 0
   },
   "hits": {
-    "total": 51,
-    "max_score": 12.243617,
+    "total": 27047,
+    "max_score": 5.6623516,
     "hits": [
       {
         "_index": "article_page_view-2015-09-29",
         "_type": "logs",
-        "_id": "AVAeBBiryhEyehZAoNFt",
-        "_score": 12.243617,
+        "_id": "AVAeAfaIyhEyehZAntY_",
+        "_score": 5.6623516,
         "_source": {
           "@version": "1",
-          "@timestamp": "2015-09-30T11:29:52.058Z",
+          "@timestamp": "2015-09-30T11:27:34.810Z",
           "tags": [
             "VIEW"
           ],
-          "article_uuid": "0049a468-4be5-11e5-b558-8a9722977189",
-          "title": "Private equity secondaries evolve with Palamon deal",
-          "initial_publish_date": "2015-08-26T17:32:01.000Z",
-          "view_timestamp": "2015-09-29T03:02:22.000Z",
+          "article_uuid": "cf9f73e8-62d6-11e5-9846-de406ccb37f2",
+          "title": "Seven reasons Volkswagen is worse than Enron",
+          "initial_publish_date": "2015-09-27T03:06:49.000Z",
+          "view_timestamp": "2015-09-29T11:18:58.000Z",
           "view_date": "2015-09-29",
           "user_cohort": "anonymous",
-          "time_on_page": 0,
-          "geo_country": "USA",
-          "geo_region": "US",
+          "time_on_page": 134,
+          "geo_country": "ESP",
+          "geo_region": "EUROPE",
           "channel": "ft.com",
-          "referrer_type": "social-network",
-          "referrer_name": "Twitter",
-          "referrer": "http://t.co/XNYTj1jIzq",
-          "device_type": "Mobile Phone",
-          "authors": [
-            "Joseph Cotterill"
-          ],
+          "referrer_type": "",
+          "referrer_name": "",
+          "referrer": "http://blogs.elconfidencial.com/mercados/valor-anadido/2015-09-29/volkswagen-puede-desaparecer-su-fraude-es-aun-peor-que-el-de-enron_1040790/",
+          "device_type": "Desktop",
+          "authors": [],
           "genre": [
-            "News"
+            "Comment"
           ],
           "sections": [
-            "Companies",
-            "Financials",
-            "Financial Services",
-            "Investment Strategy",
-            "UK Companies"
+            "Science & Environment",
+            "FTfm Fund Management",
+            "FTfm Opinion",
+            "Regulation & Governance"
           ],
-          "topics": [
-            "Private equity"
-          ]
+          "topics": []
         }
       }
     ]
@@ -61,78 +56,177 @@ export default [{
         {
           "key_as_string": "2015-09-29T00:00:00.000Z",
           "key": 1443484800000,
-          "doc_count": 30
+          "doc_count": 22364
         },
         {
           "key_as_string": "2015-09-30T00:00:00.000Z",
           "key": 1443571200000,
-          "doc_count": 21
+          "doc_count": 4683
         }
       ]
     },
     "referrer_names": {
-      "doc_count_error_upper_bound": 0,
-      "sum_other_doc_count": 0,
-      "buckets": [
-        {
-          "key": "Google",
-          "doc_count": 29
-        },
-        {
-          "key": "FT",
-          "doc_count": 16
-        },
-        {
-          "key": "",
-          "doc_count": 4
-        },
-        {
-          "key": "Twitter",
-          "doc_count": 2
-        }
-      ]
+      "doc_count": 11589,
+      "filtered": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 9,
+        "buckets": [
+          {
+            "key": "",
+            "doc_count": 7345
+          },
+          {
+            "key": "Google",
+            "doc_count": 1734
+          },
+          {
+            "key": "Facebook",
+            "doc_count": 1491
+          },
+          {
+            "key": "Twitter",
+            "doc_count": 649
+          },
+          {
+            "key": "The Business Insider",
+            "doc_count": 200
+          },
+          {
+            "key": "Linked-In",
+            "doc_count": 81
+          },
+          {
+            "key": "Google News",
+            "doc_count": 31
+          },
+          {
+            "key": "Other email",
+            "doc_count": 27
+          },
+          {
+            "key": "Bing",
+            "doc_count": 16
+          },
+          {
+            "key": "Yahoo",
+            "doc_count": 6
+          }
+        ]
+      }
+    },
+    "referrer_urls": {
+      "doc_count": 11589,
+      "filtered": {
+        "doc_count_error_upper_bound": 7,
+        "sum_other_doc_count": 4291,
+        "buckets": [
+          {
+            "key": "http://www.bloombergview.com/articles/2015-09-29/ritholtz-s-reads-seven-reasons-vw-may-be-worse-than-enron",
+            "doc_count": 2535
+          },
+          {
+            "key": "http://blogs.elconfidencial.com/mercados/valor-anadido/2015-09-29/volkswagen-puede-desaparecer-su-fraude-es-aun-peor-que-el-de-enron_1040790/",
+            "doc_count": 1509
+          },
+          {
+            "key": "http://m.facebook.com",
+            "doc_count": 663
+          },
+          {
+            "key": "http://www.ritholtz.com/blog/2015/09/10-tuesday-am-reads-179/",
+            "doc_count": 558
+          },
+          {
+            "key": "https://www.facebook.com/",
+            "doc_count": 457
+          },
+          {
+            "key": "",
+            "doc_count": 432
+          },
+          {
+            "key": "https://www.google.com/",
+            "doc_count": 397
+          },
+          {
+            "key": "http://www.ritholtz.com/blog/",
+            "doc_count": 338
+          },
+          {
+            "key": "http://lnkd.in",
+            "doc_count": 210
+          },
+          {
+            "key": "https://www.google.co.uk/",
+            "doc_count": 199
+          }
+        ]
+      }
     },
     "referrer_types": {
-      "doc_count_error_upper_bound": 0,
-      "sum_other_doc_count": 0,
-      "buckets": [
-        {
-          "key": "search",
-          "doc_count": 29
-        },
-        {
-          "key": "internal",
-          "doc_count": 16
-        },
-        {
-          "key": "",
-          "doc_count": 4
-        },
-        {
-          "key": "social-network",
-          "doc_count": 2
-        }
-      ]
+      "doc_count": 11589,
+      "filtered": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "",
+            "doc_count": 7345
+          },
+          {
+            "key": "social-network",
+            "doc_count": 2140
+          },
+          {
+            "key": "search",
+            "doc_count": 1756
+          },
+          {
+            "key": "partner",
+            "doc_count": 287
+          },
+          {
+            "key": "news-sharing",
+            "doc_count": 31
+          },
+          {
+            "key": "email",
+            "doc_count": 30
+          }
+        ]
+      }
     },
     "regions": {
       "doc_count_error_upper_bound": 0,
       "sum_other_doc_count": 0,
       "buckets": [
         {
-          "key": "UK",
-          "doc_count": 21
+          "key": "US",
+          "doc_count": 11854
         },
         {
           "key": "EUROPE",
-          "doc_count": 11
+          "doc_count": 7675
         },
         {
-          "key": "US",
-          "doc_count": 11
+          "key": "UK",
+          "doc_count": 4177
         },
         {
           "key": "ASIA",
-          "doc_count": 8
+          "doc_count": 2020
+        },
+        {
+          "key": "",
+          "doc_count": 626
+        },
+        {
+          "key": "INDIA",
+          "doc_count": 423
+        },
+        {
+          "key": "MIDDLEEAST",
+          "doc_count": 272
         }
       ]
     },
@@ -142,15 +236,19 @@ export default [{
       "buckets": [
         {
           "key": "ft.com",
-          "doc_count": 41
+          "doc_count": 21761
         },
         {
           "key": "",
-          "doc_count": 8
+          "doc_count": 4401
+        },
+        {
+          "key": "FT app",
+          "doc_count": 469
         },
         {
           "key": "next",
-          "doc_count": 2
+          "doc_count": 416
         }
       ]
     },
@@ -160,106 +258,72 @@ export default [{
       "buckets": [
         {
           "key": "Desktop",
-          "doc_count": 36
+          "doc_count": 19503
         },
         {
           "key": "Mobile Phone",
-          "doc_count": 11
-        },
-        {
-          "key": "",
-          "doc_count": 2
+          "doc_count": 4517
         },
         {
           "key": "Tablet",
-          "doc_count": 2
+          "doc_count": 2062
+        },
+        {
+          "key": "",
+          "doc_count": 953
+        },
+        {
+          "key": "Media Player",
+          "doc_count": 12
         }
       ]
     },
     "avg_time_on_page": {
-      "value": 2.450980392156863
+      "value": 54.02166598883425
     },
     "countries": {
-      "doc_count_error_upper_bound": 0,
-      "sum_other_doc_count": 0,
+      "doc_count_error_upper_bound": 4,
+      "sum_other_doc_count": 6373,
       "buckets": [
         {
-          "key": "GBR",
-          "doc_count": 21
-        },
-        {
           "key": "USA",
-          "doc_count": 11
+          "doc_count": 9397
         },
         {
-          "key": "ITA",
-          "doc_count": 7
+          "key": "GBR",
+          "doc_count": 4177
         },
         {
-          "key": "SGP",
-          "doc_count": 4
+          "key": "ESP",
+          "doc_count": 2424
+        },
+        {
+          "key": "CAN",
+          "doc_count": 1129
+        },
+        {
+          "key": "DEU",
+          "doc_count": 736
         },
         {
           "key": "AUS",
-          "doc_count": 2
+          "doc_count": 601
         },
         {
-          "key": "CHE",
-          "doc_count": 2
+          "key": "BRA",
+          "doc_count": 601
         },
         {
-          "key": "HKG",
-          "doc_count": 2
+          "key": "SWE",
+          "doc_count": 573
         },
         {
-          "key": "NGA",
-          "doc_count": 2
-        }
-      ]
-    },
-    "referrer_url": {
-      "doc_count_error_upper_bound": 0,
-      "sum_other_doc_count": 8,
-      "buckets": [
-        {
-          "key": "",
-          "doc_count": 15
+          "key": "FRA",
+          "doc_count": 536
         },
         {
-          "key": "https://www.google.co.uk/",
-          "doc_count": 10
-        },
-        {
-          "key": "https://www.google.com/",
-          "doc_count": 4
-        },
-        {
-          "key": "http://lnkd.in",
-          "doc_count": 2
-        },
-        {
-          "key": "http://localhost:3000/articles/0049a468-4be5-11e5-b558-8a9722977189",
-          "doc_count": 2
-        },
-        {
-          "key": "http://t.co/XNYTj1jIzq",
-          "doc_count": 2
-        },
-        {
-          "key": "http://www.google.co.uk/url?sa=t&rct=j&q=&esrc=s&source=web&cd=5&cad=rja&uact=8&ved=0CDoQFjAEahUKEwjf8efynJzIAhXJ2BoKHf3YAxs&url=http%3A%2F%2Fwww.ft.com%2Fcms%2Fs%2F0%2F0049a468-4be5-11e5-b558-8a9722977189.html&usg=AFQjCNG31f1iiplUDLMQ8LxTuqbNA4aKow&sig2=C-PnoY0bDpTvLhp1pMeohg",
-          "doc_count": 2
-        },
-        {
-          "key": "http://www.google.co.uk/url?sa=t&rct=j&q=&esrc=s&source=web&cd=8&ved=0CDYQFjAHahUKEwiAteSWnJ7IAhVIWBQKHcPFDbI&url=http%3A%2F%2Fwww.ft.com%2Fcms%2Fs%2F0%2F0049a468-4be5-11e5-b558-8a9722977189.html&usg=AFQjCNG31f1iiplUDLMQ8LxTuqbNA4aKow",
-          "doc_count": 2
-        },
-        {
-          "key": "https://www.google.ch",
-          "doc_count": 2
-        },
-        {
-          "key": "https://www.google.com.au/",
-          "doc_count": 2
+          "key": "IRL",
+          "doc_count": 500
         }
       ]
     }

--- a/test/formatters/Articles.spec.js
+++ b/test/formatters/Articles.spec.js
@@ -57,6 +57,7 @@ describe('Article Formatter', function() {
           'channels',
           'referrer_types',
           'referrer_names',
+          'referrer_urls',
           'devices'
         ];
         for (let i = 0; i < props.length; i++){
@@ -65,6 +66,7 @@ describe('Article Formatter', function() {
         done();
       })
       .catch((error) => {
+        console.error('error', error);
         done(error);
       });
   });

--- a/test/queries/Articles.spec.js
+++ b/test/queries/Articles.spec.js
@@ -91,6 +91,7 @@ describe('Articles Query', () => {
       'channels',
       'referrer_names',
       'referrer_types',
+      'referrer_urls',
       'devices'
     ];
     for (let i = 0; i < props.length; i++) {


### PR DESCRIPTION
So i've added a referrer table that has the links to the articles.
Unfortunately there is no straightforward way of loading twitter urls
from t.co urls, but the rest is there - we now have a list of referral
urls that are links which actually open. How cool is that? 💪
![screen shot 2015-10-02 at 11 22 58](https://cloud.githubusercontent.com/assets/780409/10244537/ef402b8a-68f7-11e5-9f7f-157063fe39d7.png)