### PR TITLE
Custom 404 message

### DIFF
--- a/src/shared/handlers/404.js
+++ b/src/shared/handlers/404.js
@@ -17,20 +17,40 @@ class Error404View extends React.Component {
   }
 
   render() {
-    let title = 'Lantern - Page Not Found'
-    let message =["Ooops!","We could not find the article."," Perhaps the article was published less than 24 hours ago?"]
+    let title = this.props.title;
+    let message = this.props.message;
+    let extraMessage = this.props.extra;
+
     return (<DocumentTitle title={title}>
       <div>
         <main>
           <Row>
             <Col xs={12}  >
               <Logo message={message} error />
-              </Col>
+            </Col>
+          </Row>
+          <Row
+            style={{
+              fontSize: '0.75em',
+              marginTop: '40px'
+            }}>
+            <Col xs={12} >
+              { extraMessage }
+            </Col>
           </Row>
         </main>
       </div>
     </DocumentTitle>);
   }
 }
+
+Error404View.defaultProps = {
+   title : 'Lantern - Page Not Found',
+   message : [
+     "Ooops!",
+     "We could not find the page you requested."
+   ],
+   extra: ''
+};
 
 export default Error404View;

--- a/src/shared/handlers/Article.js
+++ b/src/shared/handlers/Article.js
@@ -46,7 +46,6 @@ const STYLES = {
 };
 const MESSAGES = {
   PLACEHOLDER : (<div></div>),
-  ERROR_404 : (<div><Error404/></div>),
   LOADING : (
     <div style={STYLES.LOADING}>
       <Logo message="Loading Article..." loading />
@@ -134,7 +133,21 @@ class ArticleView extends React.Component {
 
   render() {
     if (this.props.errorMessage) {
-      return MESSAGES.ERROR_404;
+      return (<div>
+          <Error404
+            title="Lantern - Article Not Found"
+            message={[
+              'Ooops!',
+              'We could not find the aricle you requested',
+              'Perhaps the article was published less than 24 hours ago?'
+              ]}
+            extra={
+              <pre>
+                {this.props.errorMessage}
+              </pre>
+            }
+          />
+        </div>);
     } else if (!this.props.data) {
       return MESSAGES.LOADING;
     }


### PR DESCRIPTION
404s and article errors give out distinct messages out to not confuse article not found with an actual 404 page

<img width="492" alt="screen shot 2015-10-14 at 11 04 25" src="https://cloud.githubusercontent.com/assets/780409/10480665/61283458-7263-11e5-84b6-750cffa99a8e.png">
<img width="587" alt="screen shot 2015-10-14 at 11 01 54" src="https://cloud.githubusercontent.com/assets/780409/10480666/613bc3e2-7263-11e5-94ed-6c233d4735b3.png">
