### PR TITLE
Listener cleanup

### DIFF
--- a/src/shared/actions/ArticleActions.js
+++ b/src/shared/actions/ArticleActions.js
@@ -8,7 +8,8 @@ class ArticleActions {
       'updateData',
       'loadingFailed',
       'destroy',
-      'listenToQuery'
+      'listenToQuery',
+      'unlistenToQuery'
     );
   }
 

--- a/src/shared/actions/ComparatorActions.js
+++ b/src/shared/actions/ComparatorActions.js
@@ -9,7 +9,8 @@ class ComparatorActions {
       'updateData',
       'loadingFailed',
       'destroy',
-      'listenToQuery'
+      'listenToQuery',
+      'unlistenToQuery'
     );
   }
 

--- a/src/shared/handlers/ArticleView.js
+++ b/src/shared/handlers/ArticleView.js
@@ -134,6 +134,8 @@ class ArticleView extends React.Component {
   }
 
   componentWillUnmount() {
+    ArticleActions.unlistenToQuery();
+    ComparatorActions.unlistenToQuery();
     ArticleActions.destroy();
     ComparatorActions.destroy();
     ArticleQueryActions.destroy();

--- a/src/shared/stores/ArticleStore.js
+++ b/src/shared/stores/ArticleStore.js
@@ -15,10 +15,19 @@ class ArticleStore {
     this.loading = false;
     this.bindActions(ArticleActions);
     this.exportAsync(ArticleSource);
+    this._queryHandlerRef = null;
   }
 
   listenToQuery() {
-    ArticleQueryStore.listen(this.loadData.bind(this));
+    if (this._queryHandlerRef) return;
+    this._queryHandlerRef = this.loadData.bind(this);
+    ArticleQueryStore.listen(this._queryHandlerRef);
+  }
+
+  unlistenToQuery() {
+    if (!this._queryHandlerRef) return;
+    ArticleQueryStore.unlisten(this._queryHandlerRef);
+    this._queryHandlerRef = null;
   }
 
   loadData(store) {

--- a/src/shared/stores/ComparatorStore.js
+++ b/src/shared/stores/ComparatorStore.js
@@ -14,10 +14,19 @@ class ComparatorStore {
     this.loading = false;
     this.bindActions(ComparatorActions);
     this.exportAsync(ComparatorSource);
+    this._queryHandlerRef = null;
   }
 
   listenToQuery() {
-    ComparatorQueryStore.listen(this.loadData.bind(this));
+    if (this._queryHandlerRef) return;
+    this._queryHandlerRef = this.loadData.bind(this)
+    ComparatorQueryStore.listen(this._queryHandlerRef);
+  }
+
+  unlistenToQuery() {
+    if (!this._queryHandlerRef) return;
+    ComparatorQueryStore.unlisten(this._queryHandlerRef);
+    this._queryHandlerRef = null;
   }
 
   loadingData() {


### PR DESCRIPTION
* Unlisten from the store when unloading article view
* do not allow more than one query change handlers per store.
