### PR TITLE
Search optimisations

### DIFF
--- a/src/server/queries/Search.js
+++ b/src/server/queries/Search.js
@@ -8,7 +8,9 @@ export default function SearchQuery(query) {
   assert.equal(typeof query.term, 'string',
     "argument 'query' must contain a 'term' property of type string");
 
-  return {
+  let queryLength = query.term.split(' ').length;
+
+  let queryObject = {
     query : {
       bool : {
         must : {
@@ -32,6 +34,24 @@ export default function SearchQuery(query) {
           }
         ]
       }
-    }
+    },
+    sort : [
+      {
+        _score : {
+          order: 'desc'
+        }
+      },
+      {
+        initial_publish_date: {
+          order: 'desc'
+        }
+      }
+    ]
   };
+
+  if (queryLength === 1) {
+    queryObject.sort.reverse();
+  }
+
+  return queryObject;
 }

--- a/src/shared/components/Search.js
+++ b/src/shared/components/Search.js
@@ -93,7 +93,7 @@ export default class Search extends React.Component {
         bsSize='large'
         type='search'
         addonBefore='Search'
-        onChange={_.debounce(this._handleSearchInput.bind(this), 300)}
+        onChange={_.debounce(this._handleSearchInput.bind(this), 400)}
         >
       </Input>
       { additionalInfo }

--- a/src/shared/utils/DataAPIUtils.js
+++ b/src/shared/utils/DataAPIUtils.js
@@ -74,26 +74,30 @@ let DataAPI = {
 
     search(query, from = 0, apiKey = '') {
 
-      assert.equal(typeof query, 'string',
-        "argument 'query' must be a string");
+      assert.equal(typeof query, 'object',
+      "argument 'query' must be an object");
+
+      assert.equal(typeof query.term, 'string',
+      "query must contain a property 'term' of type string");
 
       return new Promise((resolve, reject) => {
-        let url = config.baseUrl + '/api/v0/search/' + query;
+        let url = config.baseUrl + '/api/v0/search/' + query.term;
 
         const params = {
           from : from,
           apiKey : apiKey
         };
-
+        let requestId = query.requestId;
         request.get(url)
           .query(params)
           .set('Accept', 'application/json')
           .end((err, res) => {
             if (err) {
-              err.queryData = query;
+              err.queryData = query.term;
               err.name = errorName('Search', err)
               reject(err);
             }
+            res.body.requestId = requestId;
             !err && resolve(res.body);
           });
 

--- a/test/utils/DataAPIUtils.spec.js
+++ b/test/utils/DataAPIUtils.spec.js
@@ -30,14 +30,14 @@ describe("Data Api Utils", () => {
       expect(() => DataAPIUtils.search()).to.throw();
     });
 
-    it('should throw an exception if a non string query is passed', () => {
+    it('should throw an exception if a non object query is passed', () => {
       expect(() => DataAPIUtils.search(123)).to.throw();
-      expect(() => DataAPIUtils.search({})).to.throw();
+      expect(() => DataAPIUtils.search('123')).to.throw();
       expect(() => DataAPIUtils.search(false)).to.throw();
     });
 
-    it('should not throw  if a string query is passed', () => {
-      expect(() => DataAPIUtils.search('123')).not.to.throw();
+    it('should not throw if a query object is passed', () => {
+      expect(() => DataAPIUtils.search({term: '123'})).not.to.throw();
     });
 
   });


### PR DESCRIPTION
- [x] tweaked search to sort results by date if sending a single word
(i.e. "apple")
- [x] Added secondary date sorting for phrasal queries
- [x] Added a mechanism to only display results from most recent query on the store, by keeping an UUID of the last query performed, and only updating the results if they contain a UUID that matches the last query requested

Unfortunately ES6 promises can't be cancelled so that's the only way we
can implement this