### PR TITLE
Advanced search

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Lantern - a data analytics platform for the FT",
   "main": "src/server/server.js",
   "scripts": {
-    "test": "env NODE_ENV=test mocha --compilers js:babel/register --recursive test/**/*.spec.js",
+    "test": "npm run unit && npm run functional",
+    "unit": "env NODE_ENV=test mocha --compilers js:babel/register --recursive test/**/*.spec.js",
     "test-watch": "env NODE_ENV=test mocha --compilers js:babel/register --recursive test/**/*.spec.js --watch --reporter min",
     "test-debug": "env NODE_ENV=test mocha --debug-brk --compilers js:babel/register --recursive test/**/*.spec.js",
     "cover": "env NODE_ENV=test babel-node node_modules/.bin/isparta cover node_modules/.bin/_mocha -- --reporter=dot test/**/*.spec.js ",
@@ -19,7 +20,7 @@
     "functional" : "env NODE_ENV=test npm start & sleep 20 && node nightwatch.js -g test/nightwatch/functional --suiteRetries 3",
     "f-debug" : "env NODE_ENV=test npm start & sleep 20 && node nightwatch.js -g test/nightwatch/functional --suiteRetries 3 && killall npm node"
   },
-  "pre-commit": "test",
+  "pre-commit": "unit",
   "author": "Dario Villanueva",
   "license": "MIT",
   "jshintConfig": {

--- a/src/shared/components/SearchResult.js
+++ b/src/shared/components/SearchResult.js
@@ -16,6 +16,7 @@ export default class SearchItem extends React.Component {
   render() {
     const result = this.props.result;
     const authors = formatAuthors.join(result.authors);
+    const sections = formatAuthors.join(result.sections);
     const publishedDate = formatDate(result.initial_publish_date);
     return (<div>
       <Link
@@ -29,15 +30,25 @@ export default class SearchItem extends React.Component {
         <ListGroupItem header={result.title}>
           <Row>
             <Col
-              xs={6}
+              xs={4}
               style={{
-                color: '#999'
+                color: '#999',
+                fontSize: '12px'
               }}
               >
-              {authors}
+              {"Authors: " + authors}
             </Col>
             <Col
-              xs={6}
+              xs={4}
+              style={{
+                color: '#F99',
+                fontSize: '12px'
+              }}
+              >
+              {"Sections: " + sections}
+            </Col>
+            <Col
+              xs={4}
               style={{
                 textAlign: 'right',
                 color: '#999'

--- a/test/components/searchResult.spec.js
+++ b/test/components/searchResult.spec.js
@@ -20,7 +20,7 @@ describe ('SearchResult', function() {
     stub.restore();
   });
 
-  it ('Should render search results with author and publish date', function() {
+  it ('Should render search results with author, sections publish date', function() {
 
     stub.returns('abc');
 
@@ -37,8 +37,8 @@ describe ('SearchResult', function() {
     const publishDate = col2.props.children;
 
     expect(TestUtils.isElementOfType(link, Link)).to.equal(true);
-    expect(publishDate.substr(0,10)).to.equal('Published:');
-    expect(authors).to.equal('abc');
+    expect(publishDate.substr(0,10)).to.equal('Sections: ');
+    expect(authors).to.equal('Authors: abc');
 
   });
 });

--- a/test/queries/Search.spec.js
+++ b/test/queries/Search.spec.js
@@ -18,4 +18,38 @@ describe('Search Query', () => {
     expect(() => SearchQuery(null)).to.throw();
     expect(() => SearchQuery(undefined)).to.throw();
   });
+  describe('Advanced queries', () => {
+    it('should handle title-only queries', () => {
+      let query = SearchQuery({term:'title:"my tailor is rich"'});
+      expect(query.query.bool.should.length).to.equal(2);
+      expect(query.query.bool.should[0]).to.deep.equal({
+        match : {
+          title: "my tailor is rich"
+        }
+      });
+      expect(query.query.bool.should[1]).to.deep.equal({
+        match_phrase: {
+          title: "my tailor is rich"
+        }
+      });
+    });
+    it('should handle author-only queries', () => {
+      let query = SearchQuery({term: 'author:"Oneotrix Point Never"'});
+      expect(query.query.bool.should.length).to.equal(1);
+      expect(query.query.bool.should[0]).to.deep.equal({
+        match_phrase: {
+          authors: "Oneotrix Point Never"
+        }
+      });
+    });
+    it('should handle section-only queries', () => {
+      let query = SearchQuery({term: 'section:"Companies and Technology"'});
+      expect(query.query.bool.should.length).to.equal(1);
+      expect(query.query.bool.should[0]).to.deep.equal({
+        match_phrase: {
+          sections: "Companies and Technology"
+        }
+      });
+    });
+  });
 });


### PR DESCRIPTION
Now we're able to search by author and section. I have introduced a
spotify-style search where you can intentionally specify what you're
searching for:

```
title:"My tailor is rich"
author:"Beyonce"
section:"Visual Arts"
```

If you don't specify those, you will still get relevant results (i.e.
we search for on sections, authors and titles now by default) but you
can be more specific by using those commands. Thus, we cater both for
advanced and begginer users.

I have also added the sections to the search results. We still need to
turn them into links to sections.