### PR TITLE
(wip) check all formatted fields

### DIFF
--- a/src/server/utils/universalDataFormatter.js
+++ b/src/server/utils/universalDataFormatter.js
@@ -15,6 +15,7 @@ function getField(d, f, divisor){
       let error = new Error(e);
       error.name = 'DataParsingError';
       error.data = d;
+      //todo: throw + catch properly then test it
     }
   }
   return field.formatter ? field.formatter(parent, field, divisor) : parent
@@ -82,6 +83,7 @@ function formatPublishDate(date, fieldObj, divisor) {
 
 function format(agg, fieldObj, divisor=1) {
   if (!agg){
+    //todo: throw + catch properly then test it
     return new Error(`formatterError: ${fieldObj && fieldObj.name ? fieldObj.name : fieldObj} does not exist in the data`)
   }
   return agg.buckets.map((d, i) => {

--- a/test/formatters/universalDateFormatter.spec.js
+++ b/test/formatters/universalDateFormatter.spec.js
@@ -7,6 +7,7 @@ import article_comparator_results from '../fixtures/data/article_comparator_resu
 describe('universalDataFormatter', function() {
 
   let [sectionMetaData, sectionData] = section_results
+  let [articleComparatorData, eventData]  = article_comparator_results
 
   it('should parse sectionMetaData correctly', function() {
     expect(getField(sectionMetaData, 'articleCount')).to.be.a('number')
@@ -30,9 +31,33 @@ describe('universalDataFormatter', function() {
     ])
   });
 
+  it('should parse format function with a divisor', function() {
+
+    expect(getField(sectionMetaData, 'topic_count')).to.be.a('array')
+    expect(getField(sectionMetaData, 'topic_count', 2)).to.deep.equal([
+      ["uk", 144],
+      ["banks", 42],
+      ["acquisitions", 34],
+      ["mergers", 34],
+      ["in", 26],
+      ["europe", 24],
+      ["britain", 23],
+      ["government", 19],
+      ["tax", 18],
+      ["european", 17]
+    ])
+  });
+
+  it('should parse divide function with a divisor', function() {
+    expect(getField(articleComparatorData, 'category_average_view_count')).to.be.a('number')
+    expect(getField(articleComparatorData, 'category_average_view_count')).to.deep.equal(172)
+    expect(getField(articleComparatorData, 'category_average_view_count', 2)).to.be.a('number')
+    expect(getField(articleComparatorData, 'category_average_view_count', 2)).to.deep.equal(86)
+  });
+
   xit('should error when data can not be found', function(){
-    expect(getField(sectionMetaData, 'readTimes')).to.be.a('function')
-    expect(getField(sectionMetaData, 'readTimes')).to.be.a('function')
+    expect(getField(sectionMetaData, 'readTimes')).to.throw()
+    expect(getField(sectionMetaData, 'readTimes')).to.throw()
   });
 
   describe('should parse sectionData correctly', function() {


### PR DESCRIPTION
add test to check the formatter when using a divisor value (i.e. which is used for comparators)
 - [ ]  title
 - [ ]  comparator 
 - [ ]  uuid 
 - [ ]  author
 - [ ]  genre
 - [ ]  sections
 - [ ]  topics
 - [ ]  published
 - [ ]  published_human
 - [x]  pageViews
 - [ ] timeOnPage
 - [x]  topic_count
 - [x]  topic_views
 - [x]  topicsCovered
 - [x]  articleCount
 - [ ]  category_article_count
 - [ ]  distinctArticleCount
 - [ ]  category_total_view_count
 - [ ]  category_average_view_count
 - [ ]    page_views_over_time
 - [x]    readTimes
 - [ ]    readTimesSincePublish
 - [ ]    channels
 - [x]    referrer_types
 - [x]    referrer_names
 - [ ]    referrer_urls
 - [x]    social_referrers
 - [x]    devices
 - [x]    countries
 - [x]    regions
 - [ ]    is_last_page
 - [x]    user_cohort
 - [x]    rfv_cluster
 - [x]    is_first_visit
 - [ ]    internal_referrer_urls
 - [x]    internal_referrer_types
 - [ ]    next_internal_url
 - [x]    is_subscription
 - [ ]    total_comments_posted
 - [ ]    total_comments_viewed
 - [ ]    social_shares_total
 - [ ]    social_shares_types
 - [ ]    total_links_clicked
 - [ ]    scroll_depth
 - [ ]    link_click_categories
 - [x]    unique_visitors