### PR TITLE
fix for when we're navigating to sections on client side

### DIFF
--- a/src/shared/handlers/SectionView.js
+++ b/src/shared/handlers/SectionView.js
@@ -84,6 +84,10 @@ class SectionView extends React.Component {
     //analytics.trackScroll();
     SectionActions.listenToQuery();
     ComparatorActions.listenToQuery();
+    if (!this.props.data) {
+      SectionActions.loadData(this.props);
+      ComparatorActions.loadData(this.props);
+    }
   }
 
   render() {
@@ -209,7 +213,7 @@ class SectionView extends React.Component {
               comparatorData={comparatorData}
               renderWho={FeatureFlag.check('section:who')}
               />
-            
+
             <Row>
               <Col xs={12}>
                 <h5>Where do the users come from?</h5>

--- a/src/shared/stores/SectionStore.js
+++ b/src/shared/stores/SectionStore.js
@@ -26,7 +26,7 @@ class SectionStore {
 
   unlistenToQuery() {
     if (!this._queryHandlerRef) return;
-    SectionQueryStore.listen(this._queryHandlerRef);
+    SectionQueryStore.unlisten(this._queryHandlerRef);
     this._queryHandlerRef = null;
   }
 


### PR DESCRIPTION
Sections weren't loading when navigating on client side, as the query wasn't listening before we arrive. now this should fix it.