### PR TITLE
Better debug

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,10 @@
     "watch-js": "babel src -d lib --experimental -w",
     "dev-server": "env $(cat .env) node lib/server/webpack",
     "server": "nodemon lib/server/server",
-    "debug": "env $(cat .env) nodemon --debug lib/server/server",
+    "server-debug": "env $(cat .env) nodemon --debug lib/server/server",
     "postinstall": "npm run build && env $(cat .env) webpack --config webpack.config.prod.js",
     "start": "npm run watch-js & npm run dev-server & env $(cat .env) npm run server",
+    "start-debug" : "npm run watch-js & npm run dev-server & npm run server-debug",
     "build": "npm run clean && babel src -d lib --experimental",
     "functional": "env NODE_ENV=test npm start & sleep 20 && node nightwatch.js -g test/nightwatch/functional --suiteRetries 3",
     "f-debug": "env NODE_ENV=test npm start & sleep 20 && node nightwatch.js -g test/nightwatch/functional --suiteRetries 3 && killall npm node"


### PR DESCRIPTION
Now debugging is easier. Just install node-inspector (`npm install -g node-inspector`) and run it (`node-inspector`). In another window, run `npm run start-debug`. Now you're able to set breakpoints with `debugger` on server code with both frontend and backend livereload