### PR TITLE
Move graph axis

### DIFF
--- a/src/shared/components/BarChart.js
+++ b/src/shared/components/BarChart.js
@@ -41,17 +41,23 @@ export default class BarChart extends React.Component {
       axis: {
         rotated: this.props.reverseAxis,
         x: {
-          label: this.props.xLabel,
-          type: 'category'
+          label: {
+            text: this.props.xLabel,
+            position: 'outer-right'
+          },
+          type: 'category',
         },
         y: {
-          label: yLabel,
+          label: {
+            text: yLabel,
+            position: 'outer-top'
+          },
           max: this.props.usePercentages ? 100 : null,
           min: this.props.usePercentages ? 0 : null,
           padding: {
             top: 0,
             bottom: 0
-          }
+          },
         }
       },
       tooltip : {

--- a/src/shared/components/LineChart.js
+++ b/src/shared/components/LineChart.js
@@ -83,7 +83,10 @@ export default class LineChart extends React.Component {
       axis: {
         x: {
           type: this.props.type,
-          label: xLabel,
+          label: {
+            text: xLabel,
+            position: 'outer-right'
+          },
           tick: {
             format: (this.props.type === 'timeseries') ? formatStr : numericFormat,
             width: labelWidth,
@@ -92,7 +95,10 @@ export default class LineChart extends React.Component {
           localtime: this.state.localTime
         },
         y: {
-          label: this.props.yLabel,
+          label: {
+            text: this.props.yLabel,
+            position: 'outer-top'
+          },
           padding: {
             bottom: 0
           },


### PR DESCRIPTION
This one might be open for discussion. Sometimes the axis labels clash with the bars / lines on the graphs. 

Going from this
<img width="453" alt="screen shot 2015-11-11 at 15 22 34" src="https://cloud.githubusercontent.com/assets/900140/11094819/d35dd208-8889-11e5-99c2-b40bc851ddd7.png">

to this

<img width="452" alt="screen shot 2015-11-11 at 15 22 20" src="https://cloud.githubusercontent.com/assets/900140/11094826/db4ebcfc-8889-11e5-99e7-ab43e37c652b.png">

and this

<img width="888" alt="screen shot 2015-11-11 at 15 33 52" src="https://cloud.githubusercontent.com/assets/900140/11094832/e65e90cc-8889-11e5-998b-c52350345a71.png">


to this

<img width="890" alt="screen shot 2015-11-11 at 15 33 39" src="https://cloud.githubusercontent.com/assets/900140/11094836/eefdb9b0-8889-11e5-97f9-9ba18ff4dc21.png">

