### PR TITLE
fix non-necessary initial_publish_date query

### DIFF
--- a/src/server/queries/ArticleEventsComparator.js
+++ b/src/server/queries/ArticleEventsComparator.js
@@ -9,6 +9,14 @@ export default function ArticleEventsComparatorQuery(query) {
     "argument 'query' should be an object");
 
   let comparatorQuery = build.articleComparatorQuery(query)
+  
+  // we don't need the date range here
+  let must = comparatorQuery.filtered.query.bool.must;
+  if (must.length > 1) {
+    must.splice(0,1);
+  } else {
+    delete comparatorQuery.filtered.query.bool.must;
+  }
 
   return {
     "query" : comparatorQuery,


### PR DESCRIPTION
it was causing all the comparator events queries to return zero!

the query (w/o aggregates) now looks like:
```
{"query": {
    "filtered": {
      "query": {
        "bool": {
          "must_not": {
            "match": {
              "article_uuid": "b79cd312-62b8-11e5-a28b-50226830d644"
            }
          }
        }
      },
      "filter": {
        "bool": {
          "must": [
            {
              "range": {
                "time_since_publish": {
                  "from": 0,
                  "to": 66310.80455
                }
              }
            }
          ],
          "should": []
        }
      }
    }
  }
}
```
