### PR TITLE
Sections and topics on search page

### DIFF
--- a/src/shared/components/Logo.js
+++ b/src/shared/components/Logo.js
@@ -9,13 +9,19 @@ const style = {
   lineHeight:'3em',
 }
 
-const searchHTML = <div className="magnifying-glass logo">
-  <div className="magnifying-glass__glass"></div>
-  <div className="magnifying-glass__join"></div>
-  <div className="magnifying-glass__rod"></div>
-</div>
+const searchHTML = (
+  <div className="magnifying-glass logo">
+    <div className="magnifying-glass__glass"></div>
+    <div className="magnifying-glass__join"></div>
+    <div className="magnifying-glass__rod"></div>
+  </div>
+);
 
 export default class Logo extends React.Component {
+
+  constructor(props) {
+    super(props);
+  }
 
   componentDidMount(){
     let body = document.querySelector('body')
@@ -34,7 +40,7 @@ export default class Logo extends React.Component {
     let message = messages.map(function(str){
       return <div style={style}>{str}</div>
     });
-    return (<div className='logo' data-component='logo'>
+    let logo = (
       <div className="logo-container">
         <div className={classNames.join(' ')}>
           <div className="lantern__circle">
@@ -49,10 +55,24 @@ export default class Logo extends React.Component {
             <div className="lantern__base lantern__base--lupper"></div>
             <div className="lantern__base lantern__base--lower"></div>
           </div>
+          {additionalHTML}
         </div>
-        {additionalHTML}
       </div>
-      {message}
-    </div>);
+    );
+    return (
+      <div
+        className='logo'
+        data-component='logo'>
+        {this.props.displayLogo ? logo : null}
+        {message}
+      </div>);
   }
 }
+
+Logo.propTypes = {
+  displayLogo: React.PropTypes.bool
+};
+
+Logo.defaultProps = {
+  displayLogo : true
+};

--- a/src/shared/components/Search.js
+++ b/src/shared/components/Search.js
@@ -28,7 +28,7 @@ export default class Search extends React.Component {
     };
   }
 
-  showSearchResults(){
+  shouldPerformSearch(){
     const val = (this.refs && this.refs.searchinput) ? this.refs.searchinput.getValue() : '';
     return val.length >= MIN_SEARCH_LENGTH;
   }
@@ -48,7 +48,7 @@ export default class Search extends React.Component {
     this.setState({
       query: this.refs.searchinput.getValue()
     });
-    if (this.showSearchResults()) {
+    if (this.shouldPerformSearch()) {
       this.props.search(this.state.query);
     } else {
       this.props.destroy();
@@ -85,8 +85,87 @@ export default class Search extends React.Component {
     </div>
     );
 
+    const blockLinkStyle = {
+      marginRight: '5px',
+      marginBottom: '5px',
+      padding: '10px',
+      border: '1px solid #ddd',
+      borderRadius: '4px',
+      display: 'inline-block',
+      flexGrow: 1,
+      minWidth: '15%',
+      textAlign: 'center'
+    };
+
+    let sections = (this.props.sections || [])
+    .map((section, i) => {
+      return (
+        <Link
+          data-component='sectionResult'
+          to={'/sections/' + section}
+          key={i}
+          style={blockLinkStyle}
+          >
+          {section}
+        </Link>
+      );
+    })
+
+    let topics = (this.props.topics || [])
+    .map((topic, i) => {
+      return (
+        <Link
+          data-component='topicResult'
+          to={'/topics/' + topic}
+          key={i}
+          style={blockLinkStyle}
+          >
+          {topic}
+        </Link>
+      )
+    });
+
+    let sectionResults = (
+      <div>
+        <h2><small>Sections</small></h2>
+        <div
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap'
+          }}>
+          {sections}
+        </div>
+      </div>
+    );
+
+    let topicResults = (
+      <div>
+        <h2><small>Topics</small></h2>
+        <div
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap'
+          }}>
+          {topics}
+        </div>
+      </div>
+    );
+
+    let articleResults = (
+      <div>
+        <h2><small>Articles</small></h2>
+        <ListGroup>{results}</ListGroup>
+        { (showShowMore) ? showMore : null }
+      </div>
+    );
+
+
     return (<div data-component='search'>
-      <Logo message={isLoading?'Searching...':''} loading={isLoading} search/>
+      <Logo
+        message={isLoading ? 'Searching...' : ''}
+        loading={isLoading}
+        displayLogo={(!(results.length) && !(isLoading))}
+        search/>
       <Input
         ref="searchinput"
         labelClassName='large'
@@ -97,8 +176,9 @@ export default class Search extends React.Component {
         >
       </Input>
       { additionalInfo }
-      <ListGroup>{results}</ListGroup>
-      { (showShowMore) ? showMore : null }
+      { sections.length ? sectionResults : null}
+      { topics.length ? topicResults : null}
+      { results.length ? articleResults : null }
      </div>);
   }
 
@@ -116,3 +196,5 @@ function getAdditionalInfo(props){
   }
   return <ListGroupItem bsStyle={additionalClass} header={additionalMessage} />
 }
+
+

--- a/src/shared/stores/SearchStore.js
+++ b/src/shared/stores/SearchStore.js
@@ -2,6 +2,7 @@ import alt from '../alt';
 import assign from 'object-assign';
 import Raven from 'raven-js';
 import uuid from 'uuid';
+import _ from 'underscore';
 
 import SearchActions from '../actions/SearchActions';
 import SearchSource from '../sources/SearchSource';
@@ -10,6 +11,8 @@ class SearchStore {
 
   constructor() {
     this.results = [];
+    this.sections = [];
+    this.topics = [];
     this.errorMessage = null;
     this.loading = false;
     this.query = '';
@@ -26,6 +29,8 @@ class SearchStore {
     }
     this.loading = false;
     this.results = this.results.concat(data.results);
+    this.sections = countSortAndGetTop10(this.results, 'sections');
+    this.topics = countSortAndGetTop10(this.results, 'topics');
     this.total = data.total;
     this.from += data.results.length;
     this.errorMessage = data.results.length ? null : 'Zero Results Found';
@@ -47,6 +52,8 @@ class SearchStore {
     this.query = query;
     this.from = 0;
     this.results = [];
+    this.sections = [];
+    this.topics = [];
     this.total = 0;
     this.getInstance().search({
       term: query,
@@ -69,11 +76,27 @@ class SearchStore {
     this.query = '';
     this.loading = false;
     this.results = [];
+    this.sections = [];
+    this.topics = [];
     this.from = 0;
     this.total = 0;
     this.errorMessage = null;
   }
 
+}
+
+// given an array of results, it goes through all of the
+// results and gets a count of unique values inside the
+// array inside `property`, then it sorts them by count
+// and returns the top 10.
+function countSortAndGetTop10(results, property) {
+  let allproperties = [];
+  let propertyTypeCounts = {};
+  results.forEach((result, i) => {
+    allproperties = allproperties.concat(result[property]);
+  });
+  propertyTypeCounts = _.countBy(allproperties, (pt) => pt);
+  return _.sortBy(Object.keys(propertyTypeCounts), (pt) => -propertyTypeCounts[pt]).slice(0, 10);
 }
 
 export default alt.createStore(SearchStore, 'SearchStore');

--- a/test/components/logo.spec.js
+++ b/test/components/logo.spec.js
@@ -9,8 +9,8 @@ describe ('LOGO component', function() {
   it ('Should render', function() {
     logo = createComponent(Logo, { });
     const logoContainer = logo.props.children[0]
-    const lantern = logoContainer.props.children[0]
-    const glass = logoContainer.props.children[1]
+    const lantern = logoContainer.props.children
+    const glass = lantern.props.children[1]
     const messages = logo.props.children[1]
 
     expect(lantern.props.className).to.include('lantern');
@@ -22,8 +22,8 @@ describe ('LOGO component', function() {
   it ('Should render with a message ', function() {
     logo = createComponent(Logo, { message: 'i am a test' });
     const logoContainer = logo.props.children[0]
-    const lantern = logoContainer.props.children[0]
-    const glass = logoContainer.props.children[1]
+    const lantern = logoContainer.props.children
+    const glass = lantern.props.children[1]
     const messages = logo.props.children[1]
 
     expect(lantern.props.className).to.include('lantern');
@@ -36,7 +36,7 @@ describe ('LOGO component', function() {
   it ('Should render loading messages', function() {
     logo = createComponent(Logo, { loading: true, message: ['i am a test','and i am loading'] });
     const logoContainer = logo.props.children[0]
-    const lantern = logoContainer.props.children[0]
+    const lantern = logoContainer.props.children
     const glass = logoContainer.props.children[1]
     const messages = logo.props.children[1]
 

--- a/test/components/search.spec.js
+++ b/test/components/search.spec.js
@@ -12,7 +12,7 @@ const TestUtils = React.addons.TestUtils;
 describe('Search component', function() {
   let search;
 
-  it('Should render the search field, with an empty results list', function() {
+  it('Should render the search field, with no results', function() {
     search = createComponent(Search, {
       total: 0,
       results:[]
@@ -20,20 +20,20 @@ describe('Search component', function() {
     let searchResults = search.props.children[3];
     expect(TestUtils.isElementOfType(search.props.children[0], Logo)).to.equal(true);
     expect(TestUtils.isElementOfType(search.props.children[1], Input)).to.equal(true);
-    expect(TestUtils.isElementOfType(searchResults, ListGroup)).to.equal(true);
-    expect(searchResults.props.children.length).to.equal(0)
+    expect(TestUtils.isElementOfType(searchResults, ListGroup)).to.equal(false);
   });
 
 
   it('Should render results', function() {
     search = createComponent(Search, {
       results:[
-        {title:'dude',article_uuid:'wheres',authors:['my car?']},
-        {title:'bond',article_uuid:'james',authors:['bond']}
+        {title:'dude',article_uuid:'wheres',authors:['my car?'],sections:['film'], topics:['hangover']},
+        {title:'bond',article_uuid:'james',authors:['bond'],sections:['film'], topics:['nationalism']}
       ],
       query: 'film quotes'
     });
-    let searchResults = search.props.children[3];
+
+    let searchResults = search.props.children[5].props.children[1];
     expect(TestUtils.isElementOfType(searchResults, ListGroup)).to.equal(true);
     expect(searchResults.props.children.length).to.equal(2)
   });


### PR DESCRIPTION
The search page now displays the top ten sections and topics as returned by the search results for the articles. It's pretty neat:

![image](https://cloud.githubusercontent.com/assets/780409/11240584/ee60bd7e-8deb-11e5-83a8-2af0f67e0cfa.png)
