### PR TITLE
Refactoring Nightwatch Tests

### DIFF
--- a/test/nightwatch/functional/article-element-confirm.js
+++ b/test/nightwatch/functional/article-element-confirm.js
@@ -1,30 +1,38 @@
 var articlePage = require('../pages/article-page.js');
-
-var lanternArticleUrl = 'http://localhost:3000/articles/4f9b68d0-8713-11e5-9f8c-a8d619fa707c';
-var lanternArticleTitle = 'Lantern - Team VIP wins FT MBA Challenge of 2015';
-var lanternArticleLink = 'http://www.ft.com/cms/s/0/4f9b68d0-8713-11e5-9f8c-a8d619fa707c.html';
+var nConcat = require ('../utils/nightwatch-concat.js');
 
 module.exports = {
 
   'Initiate Test': function (browser) {
     console.log("===================================\n" +
-      ">> Starting article-view-comparison.js\n" +
+      ">> Starting article-element-confirm.js\n" +
       "===================================");
 
     browser
-      .url(lanternArticleUrl)
-      .assert.title(lanternArticleTitle)
+      .url(articlePage.exampleArticleUrl)
+      .assert.title(articlePage.exampleArticleTitle)
   },
+
+  // TODO: Assert info tags on each element
 
   'Assert elements in Modifiers Section' : function (browser) {
     assertElementsInSection(browser, 'sectionModifier');
   },
 
   'Assert elements in Header Section' : function (browser) {
-    var sectionHeaderTitle = articlePage.sectionHeader.articleTitle.selectors;
     assertElementsInSection(browser, 'sectionHeader');
-    browser.assert.attributeContains(sectionHeaderTitle.container, 'href', lanternArticleLink,
+
+    currentSection = articlePage.sectionHeader;
+
+    browser
+      .assert.attributeContains(nConcat.dataComponent(articlePage.sectionHeader.articleTitle), 'href', articlePage.exampleArticleLink,
       'href for article title is correct')
+      .assert.containsText(nConcat.dataComponent(articlePage.sectionHeader.articleTitle), 'First general strike since Syriza win brings Greece to standstill',
+      'Article title is "First general strike since Syriza win brings Greece to standstill"')
+      .assert.containsText(nConcat.dataComponent(articlePage.sectionHeader.articleAuthor), 'Kerin Hope',
+      'Article author is "Kerin Hope"')
+      .assert.containsText(nConcat.dataComponent(articlePage.sectionHeader.articlePublished), 'November 12, 2015 1:39 pm',
+      'Article was published "November 12, 2015 1:39 pm"')
   },
 
   'Assert elements in Headline Stats Section' : function (browser) {
@@ -61,19 +69,10 @@ module.exports = {
     assertElementsInSection(browser, 'sectionHow');
   },
 
-
-  'Set Date Range to known quantity' : function (browser) {
-    browser
-  },
-
-  'Compare Time on Page and Page Views to known quantities' : function (browser) {
-    browser
-  },
-
-  after : function(browser) {
+  after : function (browser) {
     browser.end();
     console.log("===================================\n" +
-      ">> Ending article-view-comparison.js\n" +
+      ">> Ending article-element-confirm.js\n" +
       "===================================")
   }
 
@@ -86,9 +85,9 @@ function assertElementsInSection (browser, sectionHeading) {
     if(section.hasOwnProperty(key)) {
       var value = section[key];
       browser
-        .assert.elementPresent(value.selectors.container.concat(value.selectors.dataComponent),
-        '"' + value.name + '" element located')
-        .assert.containsText(value.selectors.container.concat(value.selectors.heading), value.name,
+        .assert.elementPresent(nConcat.dataComponent(value),
+          '"' + value.name + '" element located')
+        .assert.containsText(nConcat.heading(value), value.name,
         '"' + value.name + '" title found')
     }
   }

--- a/test/nightwatch/functional/article-find.js
+++ b/test/nightwatch/functional/article-find.js
@@ -1,24 +1,23 @@
 var searchPage = require('../pages/search-page.js');
 
-var lanternUrl = 'http://localhost:3000';
-var lanternTitle = 'Lantern - Search';
-
 module.exports = {
+
+  // TODO: include new relic stuff
 
   'Initiate Test': function (browser) {
     console.log("===================================\n" +
-      ">> Starting article-load.js\n" +
+      ">> Starting article-find.js\n" +
       "===================================");
 
     browser
-      .url(lanternUrl)
-      .assert.title(lanternTitle)
+      .url(searchPage.lanternUrl)
+      .assert.title(searchPage.lanternTitle)
   },
 
   'Check Elements - home link & search bar' : function (browser) {
     browser
-      .assert.visible(searchPage.lanternHome)
-      .assert.visible(searchPage.searchBar)
+      .assert.visible(searchPage.lanternHome, 'Lantern icon visible')
+      .assert.visible(searchPage.searchBar, 'Lantern search bar visible')
   },
 
   'Find Article' : function (browser) {
@@ -37,10 +36,10 @@ module.exports = {
       .assert.title('Lantern - Team VIP wins FT MBA Challenge of 2015')
   },
 
-  after : function(browser) {
+  after : function (browser) {
     browser.end();
     console.log("===================================\n" +
-      ">> Ending article-load.js\n" +
+      ">> Ending article-find.js\n" +
       "===================================")
   }
 

--- a/test/nightwatch/pages/article-page.js
+++ b/test/nightwatch/pages/article-page.js
@@ -1,6 +1,11 @@
 
 module.exports = {
 
+  // Links
+  exampleArticleUrl : 'http://localhost:3000/articles/69feb35e-893d-11e5-90de-f44762bf9896',
+  exampleArticleTitle: 'Lantern - First general strike since Syriza win brings Greece to standstill',
+  exampleArticleLink: 'http://www.ft.com/cms/s/0/69feb35e-893d-11e5-90de-f44762bf9896.html',
+
   // Modifier Section
   sectionModifier: {
     tags: {
@@ -32,7 +37,7 @@ module.exports = {
   // Header Section
   sectionHeader: {
     articleTitle: {
-      name: 'Team VIP wins FT MBA Challenge of 2015',
+      name: '',
       selectors: {
         container: 'header a[href]',
         dataComponent: '',
@@ -64,7 +69,9 @@ module.exports = {
       selectors: {
         container: 'div[data-component="sectionHeadlineStats"] div:nth-child(1) > div[class="singleMetric"]',
         dataComponent: ' > p',
-        heading: ' > h3'
+        heading: ' > h3',
+        chevron: ' span[style]:nth-child(1)',
+        percentile: ' span[style]:nth-child(2)'
       }
     },
     pageViews: {
@@ -72,7 +79,9 @@ module.exports = {
       selectors: {
         container: 'div[data-component="sectionHeadlineStats"] div:nth-child(2) > div[class="singleMetric"]',
         dataComponent: ' > p',
-        heading: ' > h3'
+        heading: ' > h3',
+        chevron: ' span[style]:nth-child(1)',
+        percentile: ' span[style]:nth-child(2)'
       }
     },
     uniqueVisitors: {
@@ -80,7 +89,9 @@ module.exports = {
       selectors: {
         container: 'div[data-component="sectionHeadlineStats"] div:nth-child(3) > div[class="singleMetric"]',
         dataComponent: ' > p',
-        heading: ' > h3'
+        heading: ' > h3',
+        chevron: ' span[style]:nth-child(1)',
+        percentile: ' span[style]:nth-child(2)'
       }
     },
     scrollDepth: {
@@ -88,7 +99,9 @@ module.exports = {
       selectors: {
         container: 'div[data-component="sectionHeadlineStats"] div:nth-child(4) > div[class="singleMetric"]',
         dataComponent: ' > p',
-        heading: ' > h3'
+        heading: ' > h3',
+        chevron: ' span[style]:nth-child(1)',
+        percentile: ' span[style]:nth-child(2)'
       }
     }
   },
@@ -105,7 +118,7 @@ module.exports = {
     }
   },
 
-  // Next Sectio
+  // Next Section
   sectionNext: {
     bounceRate: {
       name: 'Bounce-Rate',
@@ -133,7 +146,9 @@ module.exports = {
       selectors: {
         container: 'div[data-component="sectionInteractiveStats"] div:nth-child(2) > div:nth-child(1) > div[class="singleMetric"]',
         dataComponent: ' span:nth-child(1)',
-        heading: ' h3'
+        heading: ' h3',
+        chevron: ' span[style]:nth-child(1)',
+        percentile: ' span[style]:nth-child(2)'
       }
     },
     socialShares: {
@@ -141,7 +156,9 @@ module.exports = {
       selectors: {
         container: 'div[data-component="sectionInteractiveStats"] div:nth-child(2) > div:nth-child(2) > div[class="singleMetric"]',
         dataComponent: ' span:nth-child(1)',
-        heading: ' h3'
+        heading: ' h3',
+        chevron: ' span[style]:nth-child(1)',
+        percentile: ' span[style]:nth-child(2)'
       }
     },
     commentsViewed: {
@@ -149,7 +166,9 @@ module.exports = {
       selectors: {
         container: 'div[data-component="sectionInteractiveStats"] div:nth-child(3) > div:nth-child(1) > div[class="singleMetric"]',
         dataComponent: ' span:nth-child(1)',
-        heading: ' h3'
+        heading: ' h3',
+        chevron: ' span[style]:nth-child(1)',
+        percentile: ' span[style]:nth-child(2)'
       }
     },
     commentsPosted: {
@@ -157,7 +176,9 @@ module.exports = {
       selectors: {
         container: 'div[data-component="sectionInteractiveStats"] div:nth-child(3) > div:nth-child(2) > div[class="singleMetric"]',
         dataComponent: ' span:nth-child(1)',
-        heading: ' h3'
+        heading: ' h3',
+        chevron: ' span[style]:nth-child(1)',
+        percentile: ' span[style]:nth-child(2)'
       }
     },
     subscriptions: {
@@ -165,7 +186,9 @@ module.exports = {
       selectors: {
         container: 'div[data-component="sectionInteractiveStats"] div:nth-child(3) > div:nth-child(3) > div[class="singleMetric"]',
         dataComponent: ' span:nth-child(1)',
-        heading: ' h3'
+        heading: ' h3',
+        chevron: ' span[style]:nth-child(1)',
+        percentile: ' span[style]:nth-child(2)'
       }
     },
     linkCategory: {

--- a/test/nightwatch/pages/search-page.js
+++ b/test/nightwatch/pages/search-page.js
@@ -1,6 +1,10 @@
 
 module.exports = {
 
+  // Links
+  lanternUrl : 'http://localhost:3000',
+  lanternTitle: 'Lantern - Search',
+
   lanternHome: 'ul a svg',
   searchBar: '[type="search"]',
   recentArticles: 'h2 span',

--- a/test/nightwatch/utils/nightwatch-concat.js
+++ b/test/nightwatch/utils/nightwatch-concat.js
@@ -1,0 +1,25 @@
+
+module.exports = {
+
+  dataComponent : dataComponent,
+  heading : heading,
+  chevron : chevron,
+  percentile : percentile
+
+};
+
+function dataComponent (jsonName){
+  return jsonName.selectors.container.concat(jsonName.selectors.dataComponent);
+}
+
+function heading (jsonName){
+  return jsonName.selectors.container.concat(jsonName.selectors.heading);
+}
+
+function chevron (jsonName){
+  return jsonName.selectors.container.concat(jsonName.selectors.chevron);
+}
+
+function percentile (jsonName){
+  return jsonName.selectors.container.concat(jsonName.selectors.percentile);
+}


### PR DESCRIPTION
 - [x] Moved all links into appropriate page objects
 - [x] Renamed functional javascript files
 - [x] Included nightwatch-concat.js in utils : this concatenates CSS locators
 - [x] Generalised page object article-page.js
 - [x] Prepared page object article-page.js with new elements (eg. chevron information)

NB: this is more of a bridge between the current testing suite and https://github.com/Financial-Times/lantern/tree/functional/known-article-check