### PR TITLE
Login page bug fix

### DIFF
--- a/src/server/routers/auth-routes.js
+++ b/src/server/routers/auth-routes.js
@@ -60,7 +60,8 @@ router.get('/auth/google/callback',
   });
 
 router.use((err, req, res, next) => {
-  res.redirect('/loginFailed?gotoUrl=' + req.session.gotoUrl);
+  let url = 'https://accounts.google.com/AccountChooser?continue=http%3A%2F%2F' + escape(req.headers.host) + escape(req.session.gotoUrl);
+  res.redirect('/loginFailed?gotoUrl=' + url);
 });
 
 export default router;


### PR DESCRIPTION
So now, when you fail your login, we redirect to google's account chooser.

![loop](https://cloud.githubusercontent.com/assets/780409/11247299/5ccca486-8e13-11e5-8180-1c75a615b5f7.gif)
