### PR TITLE
fix lack of article error messages

### DIFF
--- a/src/server/apiErrorHandler.js
+++ b/src/server/apiErrorHandler.js
@@ -19,6 +19,8 @@ export function routes(app) {
 export function statusCode(errorName){
   switch (errorName) {
     case 'ArticleNotFoundError':
+      return 404;
+      break;
     case 'ComparatorNotFoundError':
       return 404;
       break;

--- a/src/server/esClient.js
+++ b/src/server/esClient.js
@@ -63,8 +63,10 @@ export function runArticleQuery(queryData) {
   }).then((pageViewData) => {
     pageViews = pageViewData;
     return retrieveEventsData(query);
-  }).then(function(eventsData){
+  }).then((eventsData) => {
     return [pageViews, metaData, eventsData]
+  }).catch((error) => {
+    return Promise.reject(error);
   });
 }
 
@@ -79,6 +81,8 @@ export function runArticleComparatorQuery(queryData) {
     return retrieveEventsData(queryData);
   }).then(function(eventsComparatorData){
     return [comparatorData, eventsComparatorData];
+  }).catch((error) => {
+    return Promise.reject(error);
   });
 }
 
@@ -101,6 +105,9 @@ export function runSectionQuery(queryData) {
     .then((sectionData) => {
       return [metaData, sectionData]
     })
+    .catch((error) => {
+      return Promise.reject(error);
+    })
 }
 
 export function runTopicQuery(queryData) {
@@ -122,6 +129,9 @@ export function runTopicQuery(queryData) {
     })
     .then((topicData) => {
       return [metaData, topicData]
+    })
+    .catch((error) => {
+      return Promise.reject(error);
     })
 }
 
@@ -195,6 +205,15 @@ function retrieveMetaData(queryData){
     };
     client.get(request, (error, response) => {
       if (error) {
+        // handle article not found
+        if (error.status === '404') {
+          // no need to 'let'/'var' this
+          let err = new Error('Article not found');
+          err.name = 'ArticleNotFoundError';
+          err.response = response;
+          err.original = error;
+          return reject(err);
+        }
         return reject(error);
       }
       // handle article not found

--- a/src/server/routers/dataPreloader-routes.js
+++ b/src/server/routers/dataPreloader-routes.js
@@ -76,10 +76,10 @@ function getArticleData(req, res){
       let dateFrom = moment(data.published).toISOString();
       let dateTo = moment().toISOString();
       res.locals.data = {
-        "ArticleStore": {
-          data: data
+        ArticleStore: {
+          data: data,
         },
-        "ArticleQueryStore" : {
+        ArticleQueryStore : {
           query: {
             uuid: decode(req.params.uuid),
             dateFrom: dateFrom,
@@ -87,7 +87,7 @@ function getArticleData(req, res){
             filters: {}
           }
         },
-        "ComparatorQueryStore" : {
+        ComparatorQueryStore : {
           query: {
             category: 'articles',
             uuid: decode(req.params.uuid),
@@ -99,7 +99,7 @@ function getArticleData(req, res){
             filters: {}
           }
         },
-        "FilterStore" : {
+        FilterStore : {
           query: {
             filters: {}
           },
@@ -110,6 +110,12 @@ function getArticleData(req, res){
         }
       };
       return res;
+    }).catch((error) => {
+      res.locals.data = {
+        ArticleStore : {
+          errorMessage : error.message
+        }
+      }
     })
 }
 
@@ -120,6 +126,10 @@ function getComparatorData(req, res){
           data: data
       };
       return res;
+    }).catch((error) => {
+      res.locals.data.ComparatorStore = {
+        errorMessage : error.message
+      };
     })
 }
 
@@ -162,6 +172,10 @@ function getSectionData(req, res){
         }
       };
       return res;
+    }).catch((error) => {
+      res.locals.data.SectionStore = {
+        errorMessage: error.message
+      }
     })
 }
 
@@ -205,7 +219,12 @@ function getTopicData(req, res){
         }
       };
       return res;
+    }).catch((error) => {
+      res.locals.data.TopicStore = {
+        errorMessage: error.message
+      }
     })
+
   }
 
   export default router;

--- a/src/shared/components/Messaging.js
+++ b/src/shared/components/Messaging.js
@@ -54,7 +54,7 @@ const MESSAGES = {
       title={title}
       message={[
               'Ooops!',
-              'We could not find the section you requested'
+              `We could not find the ${category} you requested`
               ]}
       extra={<pre>
                 {extra}

--- a/src/shared/handlers/ArticleView.js
+++ b/src/shared/handlers/ArticleView.js
@@ -52,7 +52,6 @@ class ArticleView extends React.Component {
     let articleState = ArticleStore.getState();
     let articleQueryState = ArticleQueryStore.getState();
     let comparatorQueryState = ComparatorQueryStore.getState();
-
     return {
       articleQuery : articleQueryState.query,
       comparatorQuery : comparatorQueryState.query,
@@ -98,9 +97,22 @@ class ArticleView extends React.Component {
 
   render() {
     if (this.props.errorMessage) {
-      return (<Messaging category="Article" type="ERROR" message={this.props.errorMessage} />);
+      return (<Messaging
+        category="Article"
+        type="ERROR"
+        message={this.props.errorMessage}
+      />);
+    } else if (this.props.comparatorErrorMessage) {
+      return (<Messaging
+        category="Comparator"
+        type="ERROR"
+        message={this.props.comparatorErrorMessage}
+      />);
     } else if (!this.props.data) {
-      return (<Messaging category="Article" type="LOADING" />);
+      return (<Messaging
+        category="Article"
+        type="LOADING"
+      />);
     }
     let updating = (this.props.sectionLoading || this.props.comparatorLoading)
       ? <Messaging category="Article" type="UPDATING" />


### PR DESCRIPTION
The data preloader was not catching errors properly, so we were
ignoring the errors and not setting the errorMessage properties when
preloading the data on the server side. Now that is handled and the
article "fails" to load correctly