### PR TITLE
Reallign text in rfv explanator

### DIFF
--- a/src/shared/strings/ExplanationStrings.js
+++ b/src/shared/strings/ExplanationStrings.js
@@ -16,12 +16,12 @@ export default {
   },
   sectionWho : {
     rfv: `<b>FT Super Fans:</b> read 3.5 articles and visit us twice a day on average.
-      <b>FT Fans:</b> read 9 articles and visit us 4 times per week on average.
-      <b>Engaged, Frequent & Free:</b> read 2.6 articles and visit us 6 times per week on average.
-      <b>Borderline Engaged:</b> mainly B2B and registered users. Read 2 articles and visit us twice a week on average.
-      <b>Half Engaged:</b> even split of subscribers and registered users. Read 4 articles and visit us 3 times per month on average.
-      <b>Occasional Skimmers:</b> mainly registered or B2B users. Read 2.4 articles and visit us 4 times per 90 days on average.
-      <b>Disengaged Long Tail:</b> mainly registered or B2B users. Read 2 articles and visit us 2.6 times per 90 day period on average.`,
+  <b>FT Fans:</b> read 9 articles and visit us 4 times per week on average.
+  <b>Engaged, Frequent & Free:</b> read 2.6 articles and visit us 6 times per week on average.
+  <b>Borderline Engaged:</b> mainly B2B and registered users. Read 2 articles and visit us twice a week on average.
+  <b>Half Engaged:</b> even split of subscribers and registered users. Read 4 articles and visit us 3 times per month on average.
+  <b>Occasional Skimmers:</b> mainly registered or B2B users. Read 2.4 articles and visit us 4 times per 90 days on average.
+  <b>Disengaged Long Tail:</b> mainly registered or B2B users. Read 2 articles and visit us 2.6 times per 90 day period on average.`,
   },
   sectionWhen : {
     articleViews: `This chart shows page views over time for this article (blue)


### PR DESCRIPTION
Small fix. Rfv explanator tooltip text was out of alignment.