### PR TITLE
Add missing cursor property

### DIFF
--- a/src/shared/components/SectionWho.js
+++ b/src/shared/components/SectionWho.js
@@ -16,6 +16,7 @@ const styles = {
     'color': '#039',
     'top': '0px',
     'padding-right': '8px',
+    'cursor': 'pointer'
   },
   toolTip : {
     'white-space': 'pre-wrap'


### PR DESCRIPTION
All the tooltips were clickable on iPhone except for the RFV chart which is now fixed in this PR.