### PR TITLE
Get URL's for internal Referrers

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "extract-text-webpack-plugin": "^0.8.2",
     "file-loader": "^0.8.4",
     "history": "^1.13.0",
+    "html-entities": "^1.2.0",
     "http-aws-es": "^1.1.2",
     "intl": "^1.0.1",
     "iso": "^4.2.0",

--- a/src/server/utils/getTitleFromUrl.js
+++ b/src/server/utils/getTitleFromUrl.js
@@ -1,0 +1,67 @@
+import request from "superagent";
+import {XmlEntities} from 'html-entities';
+import {createClient as createRedisClient} from 'redis';
+
+let redisClient = {};
+let useClient;
+if (process.env.USE_MEMORY_STORE === "true") {
+  useClient = false;
+} else {
+  useClient = true;
+  let redisUrl = process.env.OPENREDIS_URL || "redis://:test@localhost:6379";
+  redisClient = createRedisClient(redisUrl);
+}
+
+const STORE_NAMESPACE = 'urls:'
+
+let entities = new XmlEntities();
+
+export default function getTitleForUrl(url) {
+  return getFromRedis(url)
+    .then((title) => {
+      return title
+    })
+    .catch((err) => {
+      return getFromCrawling(url)
+    });
+}
+
+
+function getFromRedis(url) {
+  return new Promise((resolve, reject) => {
+    if (!useClient) {
+      return reject('not using client')
+    }
+    redisClient.get(STORE_NAMESPACE + url, (err, reply) => {
+      if (err) {
+        return reject(err);
+      }
+      if (!reply) return reject('Unknown');
+      return resolve(reply);
+    });
+  });
+
+}
+
+function getFromCrawling(url) {
+  return new Promise((resolve, reject) => {
+    request.get(url)
+      .end((err, res) => {
+        if (err) {
+          if (useClient) redisClient.set(STORE_NAMESPACE + url, 'Unknown');
+          return resolve('Unknown');
+        }
+        const title = getTitleFromHTML(res.text);
+        if (useClient) {
+          redisClient.set(STORE_NAMESPACE + url, title);
+        }
+        return resolve(title);
+      });
+  });
+}
+
+export function getTitleFromHTML (html) {
+  const matches = html.match(/<title>(.*?)<\/title>/i);
+  return entities.decode(matches[1]);
+}
+

--- a/src/shared/actions/ComparatorActions.js
+++ b/src/shared/actions/ComparatorActions.js
@@ -13,9 +13,6 @@ class ComparatorActions {
     );
   }
 
-  loadingData() {
-    setImmediate(_ => this.dispatch());
-  }
 
 }
 

--- a/src/shared/components/SectionNext.js
+++ b/src/shared/components/SectionNext.js
@@ -23,9 +23,11 @@ const styles = {
 function getReferrerUrls(data, i) {
   const maxLen = 60;
   const displayString = data[0].length > maxLen ? data[0].substr(0, maxLen) + '…' : data[0];
+  let title = data[2];
+  if (!title || title === 'unknown') title = displayString;
   let url = displayString.indexOf('http') < 0 ? displayString : (
     <a target="_blank" href={data[0]}>
-      {displayString}
+      {title}
     </a>
   );
   return {

--- a/src/shared/components/SectionReferrers.js
+++ b/src/shared/components/SectionReferrers.js
@@ -16,9 +16,12 @@ function getReferrerUrls(data, i) {
   if (!/ft.com/.test(parsed.hostname)) {
     displayString = displayString.split('?')[0];
   }
+
+  let title = data[2];
+  if (!title || (title === 'Unknown')) title = displayString;
   let url = displayString.indexOf('http') < 0 ? displayString : (
     <a target="_blank" href={data[0]}>
-      {displayString}
+      {(title !== 'Unknown') ? title : displayString}
     </a>
   );
   return {

--- a/src/shared/stores/ComparatorStore.js
+++ b/src/shared/stores/ComparatorStore.js
@@ -29,13 +29,10 @@ class ComparatorStore {
     this._queryHandlerRef = null;
   }
 
-  loadingData() {
-    this.loading = true;
-  }
-
   loadData(store) {
     if (!store.query.comparator) return
-    setImmediate(_ => this.getInstance().loadComparatorData(store.query));
+    this.loading = true;
+    this.getInstance().loadComparatorData(store.query);
   }
 
   updateData(newData) {


### PR DESCRIPTION
I've added functionality to query the `<title>` tags extracted from our
internal referrer urls by loading the pages and running a regex on the
response from the server. The titles for the URL's are cached on redis
so as to avoid hammering servers.

This means that if you don't have redis installed on your dev machine
you might want to install it to avoid scraping websites too intensely.

Some websites (ft.com) throw errors and thus we show the urls instead

<img width="525" alt="screen shot 2015-11-30 at 16 43 27" src="https://cloud.githubusercontent.com/assets/780409/11477788/86c8d2ce-9781-11e5-8389-340254638d62.png">
