### PR TITLE
Stop negative `time_since_publish` page views from appearing on topic page

### DIFF
--- a/src/server/queries/Topics.js
+++ b/src/server/queries/Topics.js
@@ -11,6 +11,19 @@ export default function TopicQuery(query) {
 
   let topicQuery = build.topicQuery(query)
 
+  // There are page views for which the publish date
+  // is later than the view date. thus, time since
+  // publish is negative which is like stupid so we need to
+  // ensure view_timestamp is greater than the initial publish
+  // date
+  topicQuery.filtered.query.bool.must.push({
+    range: {
+      view_timestamp : {
+        gte : query.dateFrom
+      }
+    }
+  })
+
   let esQuery = {
     query : topicQuery,
     size: 1,


### PR DESCRIPTION
ensure topics query only spans page views with positive time_since_publish