### PR TITLE
Add missing comparator in evaluation

### DIFF
--- a/src/shared/handlers/TopicView.js
+++ b/src/shared/handlers/TopicView.js
@@ -125,7 +125,7 @@ class TopicView extends React.Component {
     } else if (!this.props.data) {
       return (<Messaging category="Topic" type="LOADING" />);
     }
-    let updating = (this.props.topicLoading)
+    let updating = (this.props.topicLoading || this.props.comparatorLoading)
       ? <Messaging category="Topic" type="UPDATING" />
       : <Messaging category="Topic" type="PLACEHOLDER" />
 


### PR DESCRIPTION
Currently the topic page doesnt display the updating overlay when loading a comparator - this fixes it...