### PR TITLE
Add the current number of readers

### DIFF
--- a/src/server/formatters/ArticleRealtimeDataFormatter.js
+++ b/src/server/formatters/ArticleRealtimeDataFormatter.js
@@ -30,8 +30,11 @@ export default function formatData(data) {
   let realtimeFields = [
     'realtimePageViews',
     'timeOnPageLastHour',
-    'scrollDepthLastHour'
+    'scrollDepthLastHour',
+    'livePageViews'
   ];
+
+  console.log(realtimeData.aggregations)
 
   let results = {}
   return new Promise((resolve, reject) => {

--- a/src/server/queries/ArticleRealTime.js
+++ b/src/server/queries/ArticleRealTime.js
@@ -95,6 +95,38 @@ export default function ArticlesRealtimeQuery(query) {
           }
         }
       },
+      live_page_views : {
+        filter: {
+          bool: {
+            must: [
+              {
+                term : {
+                  event_type : 'page'
+                }
+              },
+              {
+                term : {
+                  event_category: 'view'
+                }
+              },
+              {
+                range: {
+                  event_timestamp: {
+                    gte: "now-5m/m"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        aggs : {
+          filtered: {
+            cardinality: {
+              field: 'visitor_id'
+            }
+          }
+        }
+      },
       scroll_depth_last_hour : {
         filter: {
           bool : {

--- a/src/server/routers/dataPreloader-routes.js
+++ b/src/server/routers/dataPreloader-routes.js
@@ -133,7 +133,8 @@ function getArticleRealtimeData(req, res) {
           published_human: data.published_human,
           pageViews: data.realtimePageViews,
           timeOnPage: data.timeOnPageLastHour,
-          scrollDepth: data.scrollDepthLastHour
+          scrollDepth: data.scrollDepthLastHour,
+          livePageViews: data.livePageViews
         }
       };
       return res;

--- a/src/server/utils/universalDataFormatter.js
+++ b/src/server/utils/universalDataFormatter.js
@@ -35,6 +35,7 @@ const fields = {
   realtimePageViews: {name: 'aggregations.page_views.filtered', formatter: format},
   timeOnPageLastHour: {name: 'aggregations.time_on_page_last_hour.filtered.value', formatter: Math.round},
   scrollDepthLastHour: {name: 'aggregations.scroll_depth_last_hour.filtered.value', formatter: Math.round},
+  livePageViews: {name: 'aggregations.live_page_views.filtered.value', formatter: Math.round},
   timeOnPage: 'aggregations.avg_time_on_page.value',
   topicCount: {name: 'aggregations.topic_count', formatter: format},
   topicViews: {name: 'aggregations.topic_views', formatter: format},

--- a/src/shared/handlers/ArticleRealtimeView.js
+++ b/src/shared/handlers/ArticleRealtimeView.js
@@ -75,8 +75,12 @@ class ArticleRealtimeView extends React.Component {
       timeOnPage: {
         metricType: 'time',
         label: 'Time on Page',
-        size: 'large',
-        comparatorFormatName: 'timeOnPage'
+        size: 'large'
+      },
+      livePageViews: {
+        metricType: 'integer',
+        label: 'Current Readers',
+        size: 'large'
       },
       scrollDepth: {
         metricType: 'percentage',

--- a/src/shared/stores/ArticleRealtimeStore.js
+++ b/src/shared/stores/ArticleRealtimeStore.js
@@ -12,6 +12,7 @@ class ArticleRealtimeStore {
     this.pageViews = [];
     this.timeOnPage = null;
     this.scrollDepth = null;
+    this.livePageViews = null;
     this.author = [];
     this.genre = [];
     this.title = "";
@@ -69,6 +70,7 @@ class ArticleRealtimeStore {
       this.pageViews = processData(this.pageViews, data.realtimePageViews);
       this.timeOnPage = data.timeOnPageLastHour;
       this.scrollDepth = data.scrollDepthLastHour;
+      this.livePageViews = data.livePageViews;
       this.isLive = true;
       this.emitChange();
       this.setIsLiveTimer();
@@ -90,6 +92,7 @@ class ArticleRealtimeStore {
     this.pageViews = data.realtimePageViews;
     this.timeOnPage = data.timeOnPageLastHour;
     this.scrollDepth = data.scrollDepthLastHour;
+    this.livePageViews = data.livePageViews;
   }
 
   loadingData() {

--- a/test/fixtures/realtimeQuery.js
+++ b/test/fixtures/realtimeQuery.js
@@ -1,116 +1,147 @@
 export default {
-    "query" : {
-      "match": {
-          "article_uuid": "f02cca28-9028-11e5-bd82-c1fb87bef7af"
-      }
-    },
-    "size" : 1,
-    "aggs" : {
-        "page_views": {
-            "filter" : {
-                "bool" : {
-                    "must": [
-                        {
-                            "term" : {
-                                "event_type" : "page"
-                            }
-                        },
-                        {
-                            "term" : {
-                                "event_category" : "view"
-                            }
-                        },
-                        {
-                          "range": {
-                              "event_timestamp": {
-                                  "from" : "2015-11-24T10:15:00.000",
-                                  "to" : "2015-11-24T11:15:00.000"
-                              }
-                          }
-                        }
-                    ]
-                }
-
+  "query" : {
+    "match": {
+      "article_uuid": "f02cca28-9028-11e5-bd82-c1fb87bef7af"
+    }
+  },
+  "size" : 1,
+  "aggs" : {
+    "page_views": {
+      "filter" : {
+        "bool" : {
+          "must": [
+            {
+              "term" : {
+                "event_type" : "page"
+              }
             },
-            "aggs" : {
-                "filtered" : {
-                    "date_histogram" : {
-                        "field" : "event_timestamp",
-                        "interval" : "60s",
-                        "min_doc_count" : 0,
-                        "extended_bounds" : {
-                          "min" : "2015-11-24T10:15:00.000",
-                          "max" : "2015-11-24T11:15:00.000"
-                        }
-                    }
-                }
-            }
-        },
-        "time_on_page_last_hour": {
-            "filter" : {
-                "bool" : {
-                    "must": [
-                        {
-                            "term" : {
-                                "event_type" : "page"
-                            }
-                        },
-                        {
-                            "term" : {
-                                "event_category" : "supplement"
-                            }
-                        },
-                        {
-                            "range": {
-                                "event_timestamp": {
-                                    "gte" : "now-1h/m"
-                                }
-                            }
-                        }
-                    ]
-                }
-
+            {
+              "term" : {
+                "event_category" : "view"
+              }
             },
-            "aggs" : {
-                "filtered" : {
-                    "avg" : {
-                        "field" : "attention_time"
-                    }
+            {
+              "range": {
+                "event_timestamp": {
+                  "from" : "2015-11-24T10:15:00.000",
+                  "to" : "2015-11-24T11:15:00.000"
                 }
+              }
             }
-        },
-        "scroll_depth_last_hour": {
-            "filter" : {
-                "bool" : {
-                    "must": [
-                        {
-                            "term" : {
-                                "event_type" : "page"
-                            }
-                        },
-                        {
-                            "term" : {
-                                "event_category" : "scroll"
-                            }
-                        },
-                        {
-                            "range": {
-                                "event_timestamp": {
-                                    "gte" : "now-1h/m"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs" : {
-                "filtered" : {
-                    "avg" : {
-                        "field" : "scroll_depth"
-                    }
-                }
-            }
+          ]
         }
 
+      },
+      "aggs" : {
+        "filtered" : {
+          "date_histogram" : {
+            "field" : "event_timestamp",
+            "interval" : "60s",
+            "min_doc_count" : 0,
+            "extended_bounds" : {
+              "min" : "2015-11-24T10:15:00.000",
+              "max" : "2015-11-24T11:15:00.000"
+            }
+          }
+        }
+      }
+    },
+    "time_on_page_last_hour": {
+      "filter" : {
+        "bool" : {
+          "must": [
+            {
+              "term" : {
+                "event_type" : "page"
+              }
+            },
+            {
+              "term" : {
+                "event_category" : "supplement"
+              }
+            },
+            {
+              "range": {
+                "event_timestamp": {
+                  "gte" : "now-1h/m"
+                }
+              }
+            }
+          ]
+        }
+
+      },
+      "aggs" : {
+        "filtered" : {
+          "avg" : {
+            "field" : "attention_time"
+          }
+        }
+      }
+    },
+    live_page_views : {
+      filter: {
+        bool: {
+          must: [
+            {
+              term : {
+                event_type : 'page'
+              }
+            },
+            {
+              term : {
+                event_category: 'view'
+              }
+            },
+            {
+              range: {
+                event_timestamp: {
+                  gte: "now-5m/m"
+                }
+              }
+            }
+          ]
+        }
+      },
+      aggs : {
+        filtered: {
+          cardinality: {
+            field: 'visitor_id'
+          }
+        }
+      }
+    },
+    "scroll_depth_last_hour": {
+      "filter" : {
+        "bool" : {
+          "must": [
+            {
+              "term" : {
+                "event_type" : "page"
+              }
+            },
+            {
+              "term" : {
+                "event_category" : "scroll"
+              }
+            },
+            {
+              "range": {
+                "event_timestamp": {
+                  "gte" : "now-1h/m"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "aggs" : {
+        "filtered" : {
+          "avg" : {
+            "field" : "scroll_depth"
+          }
+        }
+      }
     }
+  }
 }


### PR DESCRIPTION
Uses a 5m window on the cardinality of visitor ids.

Could be optimised when the page view and page exit data is there.