### PR TITLE
clear dates on analytics view.

### DIFF
--- a/src/shared/handlers/ArticleView.js
+++ b/src/shared/handlers/ArticleView.js
@@ -1,11 +1,7 @@
 import React from 'react/addons';
 import DocumentTitle from 'react-document-title';
-import Col from 'react-bootstrap/lib/Col';
-import Row from 'react-bootstrap/lib/Row';
 import connectToStores from 'alt/utils/connectToStores';
-import moment from 'moment';
 import Link from 'react-router/lib/Link';
-import assign from 'object-assign';
 import _ from 'underscore';
 
 import Header from "../components/Header";
@@ -29,10 +25,6 @@ import * as formatAuthors from '../utils/formatAuthors';
 
 import ChunkWrapper from '../components/ChunkWrapper';
 
-function decode(uri){
-  return uri ? decodeURI(uri) : null
-}
-
 class ArticleView extends React.Component {
 
   constructor(props) {
@@ -55,6 +47,7 @@ class ArticleView extends React.Component {
   componentWillMount() {
     AnalyticsActions.updateQuery({
       uuid : this.props.params.uuid,
+      dateFrom: null,
       type: 'article',
       comparatorType: this.props.params.comparatorType,
       comparator: this.props.params.comparator

--- a/src/shared/stores/AnalyticsStore.js
+++ b/src/shared/stores/AnalyticsStore.js
@@ -11,12 +11,14 @@ function newState() {
     data: null,
     comparatorData: null,
     loading: false,
+    errorMessage: null,
+    error: null,
     query: {
       type: null,
       topic: null,
       section: null,
       uuid: null,
-      dateFrom: null,
+      dateFrom: moment().subtract(30, 'days').toISOString(),
       dateTo: moment().toISOString(),
       filters: {},
       comparator: 'FT',
@@ -30,25 +32,9 @@ function newState() {
 class AnalyticsStore {
 
   constructor() {
+    const state = newState();
     // props for our views
-    this.state = {
-      data: null,
-      comparatorData: null,
-      loading: false,
-      errorMessage: null,
-      query: {
-        type: null,
-        topic: null,
-        section: null,
-        uuid: null,
-        dateFrom: null,
-        dateTo: moment().toISOString(),
-        filters: {},
-        comparator: 'FT',
-        comparatorType: 'global',
-        publishDate: null
-      }
-    };
+    this.state = state;
     // add the actions
     this.bindActions(AnalyticsActions);
     this.exportAsync(AnalyticsSource);
@@ -63,8 +49,10 @@ class AnalyticsStore {
    */
   updateData(newData) {
     newData.loading = false;
-    let queryProps = assign({}, this.state.query, {dateFrom : newData.data.published})
-    newData.query = queryProps;
+    if (this.state.query.type === 'article') {
+      let queryProps = assign({}, this.state.query, {dateFrom : newData.data.published})
+      newData.query = queryProps;
+    }
     this.setState(newData);
   }
 


### PR DESCRIPTION
The query wasn't being cleared properly when we leave a section / article / topic page. It will now be cleared properly by the store. Also any errors will be cleared so that navigation will continue even if we get a 500 / 404 etc