### PR TITLE
Add default props to realtime view

### DIFF
--- a/src/shared/handlers/ArticleRealtimeView.js
+++ b/src/shared/handlers/ArticleRealtimeView.js
@@ -172,4 +172,25 @@ class ArticleRealtimeView extends React.Component {
 
 }
 
+ArticleRealtimeView.defaultProps = {
+  pageViews: [],
+  timeOnPage: null,
+  scrollDepth: null,
+  livePageViews: null,
+  totalPageViews: null,
+  realtimeNextInternalUrl: null,
+  author: [],
+  genre: [],
+  title: "[No realtime data available]",
+  topics: [],
+  sections: [],
+  published: "",
+  published_human: "",
+  errorMessage: null,
+  error: null,
+  loading: false,
+  uuid: null,
+  isLive: false
+};
+
 export default connectToStores(ArticleRealtimeView);


### PR DESCRIPTION
Fixes error showing up when there are no realtime data to show.