### PR TITLE
Added a new route decide if realtime or historical

### DIFF
--- a/src/server/esClient.js
+++ b/src/server/esClient.js
@@ -47,6 +47,13 @@ export function getIndicies(h = 'health,index,docs.count,store.size,tm'){
   });
 }
 
+export function getMetaData (uuid) {
+  let query = {
+    uuid : uuid
+  }
+  return retrieveMetaData(query);
+}
+
 export function runArticleQuery(queryData) {
   let queryError = queryDataError('articles', queryData);
   if (queryError){

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -15,11 +15,10 @@ let dataPreloader = require("./routers/dataPreloader-routes");
 let apiRouter = require("./routers/api-routes");
 let authRouter = require("./routers/auth-routes");
 let statusRouter = require("./routers/status-routes");
+import * as esClient from './esClient';
 import uuid from 'uuid';
-
 import RealtimeServer from './realtimeServer';
-
-
+import moment from 'moment';
 delete process.env.BROWSER;
 let cacheBustId = uuid();
 const app = express();
@@ -56,6 +55,20 @@ app.use('/bye', (req, res) =>{
 });
 
 app.use('/', authRouter);
+
+app.use('/landing/article/:uuid', ensureApiAuthenticated, (req, res) => {
+  esClient.getMetaData(req.params.uuid).then(function(data){
+    let publishDate = moment(data.initial_publish_date, 'YYYY-MM-DD');
+    let now = moment();
+
+    if(moment(now).isAfter(publishDate, 'day')){
+      res.redirect(`/articles/${req.params.uuid}`);
+    } else {
+      res.redirect(`/realtime/articles/${req.params.uuid}`);
+    }
+  });
+});
+
 app.use('/api/v0', ensureApiAuthenticated, apiRouter);
 app.use('/', ensureAuthenticated, dataPreloader);
 app.use('/', ensureAuthenticated, function appRouter(req, res) {
@@ -64,7 +77,6 @@ app.use('/', ensureAuthenticated, function appRouter(req, res) {
 app.use(function ErrorHandler(err, req, res, next) {
   renderRoute(errorRoutes, req, res)
 });
-
 
 //Go!!!
 var server = app.listen(config.port, function () {
@@ -111,7 +123,6 @@ function renderRoute(route, req, res) {
 
   });
 }
-
 
 function ensureAuthenticated(req, res, next) {
   if (req.isAuthenticated()


### PR DESCRIPTION
When hitting:
http://localhost:3000/realtimeOrHistorical/:uuid

It should take you to realtime if the article is published on the same day or historical if its older than a day.

The updated chrome extension PR is here:
https://github.com/Financial-Times/lantern-chrome-extension/pull/2