### PR TITLE
Remove extra line in real time view

### DIFF
--- a/src/shared/handlers/ArticleRealtimeView.js
+++ b/src/shared/handlers/ArticleRealtimeView.js
@@ -185,14 +185,12 @@ class ArticleRealtimeView extends React.Component {
           />
         </ChunkWrapper>
 
-        <ChunkWrapper component="headlineStats">
-          <SectionHeadlineStats
-            data={this.props}
-            comparatorData={{}}
-            config={headlineStats}
-          />
-        </ChunkWrapper>
-
+        <SectionHeadlineStats
+          data={this.props}
+          comparatorData={{}}
+          config={headlineStats}
+        />
+        
         <ChunkWrapper component={selectedGraphComponentName}>
           <Row>
             <Col>


### PR DESCRIPTION
Bug fix - remove the double underline thats shown here:

![screen shot 2016-01-07 at 11 47 27](https://cloud.githubusercontent.com/assets/1691942/12169944/7dd95960-b534-11e5-8651-184ef23f816e.png)
