### PR TITLE
Don't use nodemon in production

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: npm run server
+web: npm run production

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "watch-js": "babel src -d lib --experimental -w",
     "dev-server": "env $(cat .env) node lib/server/webpack",
     "server": "nodemon --max_old_space_size=${NODE_MAX_OLD_SPACE_SIZE:-0} --delay 1 lib/server/server",
+    "production": "node --max_old_space_size=${NODE_MAX_OLD_SPACE_SIZE:-0} lib/server/server.js",
     "server-debug": "env $(cat .env) nodemon --debug lib/server/server",
     "postinstall": "npm run build && env $(cat .env) webpack --config webpack.config.prod.js",
     "start": "npm run watch-js & npm run dev-server & env $(cat .env) npm run server",


### PR DESCRIPTION
- [x] Altered package.json to have a `production` run task
- [x] Changed `production` task to use plain `node` without nodemon

N.B.: Heroku will automatically restart the server if it crashes, then have a 10 minute "cool-off" period if it crashes once again:

> Heroku’s dyno restart policy is to try to restart crashed dynos by spawning new dynos once every ten minutes. This means that if you push bad code that prevents your app from booting, your app dynos will be started once, then restarted, then get a cool-off of ten minutes. In the normal case of a long-running web or worker process getting an occasional crash, the dyno will be restarted instantly without any intervention on your part. If your dyno crashes twice in a row, it will stay down for ten minutes before the system retries.

https://devcenter.heroku.com/articles/dynos#automatic-dyno-restarts