### PR TITLE
fix lack of comparator scroll depth

### DIFF
--- a/src/server/esQueries/ArticleEventsComparator.js
+++ b/src/server/esQueries/ArticleEventsComparator.js
@@ -16,10 +16,9 @@ export default function ArticleEventsComparatorESQuery(query) {
   } else {
     delete comparatorQuery.filtered.query.bool.must;
   }
-
   return {
     "query" : comparatorQuery,
-    "size": 1,
-    "aggs" : ArticleEventsComparatorAggregation
-  }
+    "size": 0,
+    "aggs" : ArticleEventsComparatorAggregation()
+  };
 }


### PR DESCRIPTION
There was a bug on the query generator where we were returning the aggregation building function rather than the aggregation. this is now fixed.

<img width="313" alt="screen shot 2016-01-14 at 11 46 47" src="https://cloud.githubusercontent.com/assets/780409/12324417/4d89e33e-baba-11e5-86b3-a2c6cf5227f5.png">
