### PR TITLE
Retention Rate Rearrangement Refactor

### DIFF
--- a/src/client/styles/_5col.scss
+++ b/src/client/styles/_5col.scss
@@ -1,0 +1,35 @@
+.col-xs-5ths,
+.col-sm-5ths,
+.col-md-5ths,
+.col-lg-5ths {
+    position: relative;
+    min-height: 1px;
+    padding-right: 10px;
+    padding-left: 10px;
+}
+
+.col-xs-5ths {
+    width: 20%;
+    float: left;
+}
+
+@media (min-width: 768px) {
+    .col-sm-5ths {
+        width: 20%;
+        float: left;
+    }
+}
+
+@media (min-width: 992px) {
+    .col-md-5ths {
+        width: 20%;
+        float: left;
+    }
+}
+
+@media (min-width: 1200px) {
+    .col-lg-5ths {
+        width: 20%;
+        float: left;
+    }
+}

--- a/src/client/styles/app.scss
+++ b/src/client/styles/app.scss
@@ -5,5 +5,6 @@
 @import "nav";
 @import "comparators";
 @import "last-updated";
+@import "5col";
 @import "../../shared/lib/daterangepicker.css";
 @import "../../shared/lib/react-select.css";

--- a/src/shared/components/SectionHeadlineStats.js
+++ b/src/shared/components/SectionHeadlineStats.js
@@ -15,8 +15,9 @@ export default class SectionHeadlineStats extends React.Component {
     function getMetrics (config, data, comparatorData) {
       let keys = Object.keys(config);
       let metrics = [];
-      let colWidth = 12 / keys.length;
-
+      let colWidth = Math.floor(12 / keys.length);
+      let isFive = keys.length === 5;
+      if (isFive) colWidth = '5ths'
       keys.forEach(function (value, i) {
         let componentConfig = config[value];
         componentConfig.metric = data[value];

--- a/src/shared/components/SectionNext.js
+++ b/src/shared/components/SectionNext.js
@@ -58,30 +58,6 @@ export default class SectionWhere extends React.Component {
       </Row>
       <Row>
         <Col xs={12} sm={6}>
-          <h4>
-            <OverlayTrigger
-              trigger="click"
-              placement="bottom"
-              overlay={
-                <Popover id="tag-description">
-                    <p><Text message='explanations.sectionNext.bounceRate' /></p>
-                </Popover>
-                }
-              >
-              <Glyphicon glyph="question-sign" style={styles.infoIcon} />
-            </OverlayTrigger>
-            What was the Bounce-Rate?
-          </h4>
-          <BarChart
-            data={metricData}
-            keys={keys}
-            category={id}
-            yLabel="Users"
-            xLabel=""
-            usePercentages={true}
-            />
-        </Col>
-        <Col xs={12} sm={6}>
           <h4>Of those who stayed where did they go?</h4>
           <Table
             headers={['Next Destination', 'Views']}

--- a/src/shared/components/SingleMetric.js
+++ b/src/shared/components/SingleMetric.js
@@ -10,15 +10,15 @@ var componentStyles = {
   'default': {
     large: {
       fontSize: '1.2em',
-      margin: '1.2em'
+      margin: '0.5em'
     },
     medium: {
       fontSize: '1.0em',
-      margin: '1.0em'
+      margin: '0.5em'
     },
     small: {
       fontSize: '0.8em',
-      margin: '0.8em'
+      margin: '0.5em'
     },
     singleMetric: {
       textAlign: 'center'
@@ -26,7 +26,7 @@ var componentStyles = {
     label: {
       padding: 0,
       margin: 0,
-      marginBottom: '15px',
+      marginBottom: '10px',
       fontSize: '1.0em',
       color: '#666666'
     },
@@ -37,7 +37,8 @@ var componentStyles = {
     },
     comparator: {
       display: 'block',
-      fontSize: '0.6em'
+      fontSize: '0.6em',
+      marginTop: '10px'
     },
     comparatorSymbol: {
       display: 'inline-block',

--- a/src/shared/handlers/ArticleView.js
+++ b/src/shared/handlers/ArticleView.js
@@ -14,7 +14,7 @@ import SectionWho from "../components/SectionWho";
 import SectionInteract from "../components/SectionInteract";
 import Text from '../components/Text'
 import Messaging from '../components/Messaging';
-
+import FormatData from "../utils/formatData";
 
 import FeatureFlag from '../utils/featureFlag';
 import * as formatAuthors from '../utils/formatAuthors';
@@ -39,6 +39,18 @@ class ArticleView extends React.Component {
     let comparatorData = this.props.comparatorData || { article: {}};
     let title = (data) ? 'Lantern - ' + data.title : '';
 
+    let dataFormatter = new FormatData(this.props.data, this.props.comparatorData);
+    let [retentionRateData, , keys] = dataFormatter.getPCTMetric('isLastPage', 'Article', 'Exited FT', 'Stayed on FT')
+
+    let dataPoint;
+    for (let i = 0; i < retentionRateData.length; i++) {
+      dataPoint = retentionRateData[i];
+      if (dataPoint.category === 'Stayed on FT') {
+        data.retentionRate = parseFloat(dataPoint[keys[0] + ' %']);
+        comparatorData.retentionRate = parseFloat(dataPoint[keys[1] + ' %']);
+      }
+    }
+
     let headlineStats = {
       timeOnPage: {
         metricType: 'time',
@@ -57,6 +69,12 @@ class ArticleView extends React.Component {
         label: 'Unique Visitors',
         size: 'large',
         comparatorFormatName: 'categoryAverageUniqueVisitors'
+      },
+      retentionRate: {
+        metricType: 'percentage',
+        label: 'Retention Rate',
+        size: 'large',
+        comparatorFormatName: 'retentionRate'
       },
       scrollDepth: {
         metricType: 'percentage',

--- a/test/nightwatch/functional/article-element-confirm.js
+++ b/test/nightwatch/functional/article-element-confirm.js
@@ -23,7 +23,7 @@ module.exports = {
   'Assert elements in Header Section' : function (browser) {
     nExtras.assertElementsInSection(browser, articlePage.sectionHeader);
 
-    currentSection = articlePage.sectionHeader;
+    var currentSection = articlePage.sectionHeader;
 
     browser
       .assert.attributeContains(nConcat.dataComponent(articlePage.sectionHeader.articleTitle), 'href', articlePage.exampleArticleLink,

--- a/test/nightwatch/pages/article-page.js
+++ b/test/nightwatch/pages/article-page.js
@@ -94,10 +94,20 @@ module.exports = {
         percentile: ' span[style]:nth-child(2)'
       }
     },
+    retentionRate: {
+      name: 'Retention Rate',
+      selectors: {
+        container: 'div[data-component="sectionHeadlineStats"] div:nth-child(4) > div[class="singleMetric"]',
+        dataComponent: ' > p',
+        heading: ' > h3',
+        chevron: ' span[style]:nth-child(1)',
+        percentile: ' span[style]:nth-child(2)'
+      }
+    },
     scrollDepth: {
       name: 'Scroll Depth',
       selectors: {
-        container: 'div[data-component="sectionHeadlineStats"] div:nth-child(4) > div[class="singleMetric"]',
+        container: 'div[data-component="sectionHeadlineStats"] div:nth-child(5) > div[class="singleMetric"]',
         dataComponent: ' > p',
         heading: ' > h3',
         chevron: ' span[style]:nth-child(1)',
@@ -120,18 +130,10 @@ module.exports = {
 
   // Next Section
   sectionNext: {
-    bounceRate: {
-      name: 'Bounce-Rate',
-      selectors: {
-        container: 'div[data-component="sectionNext"] div[class="col-sm-6 col-xs-12"]:nth-child(1)',
-        dataComponent: ' div[data-component="barChart"]',
-        heading: ' h4'
-      }
-    },
     exitPage: {
       name: 'where did they go?',
       selectors: {
-        container: 'div[data-component="sectionNext"] div[class="col-sm-6 col-xs-12"]:nth-child(2)',
+        container: 'div[data-component="sectionNext"] div[class="col-sm-6 col-xs-12"]:nth-child(1)',
         dataComponent: ' table[data-component="table"]',
         heading: ' h4'
       }


### PR DESCRIPTION
We recently reconvened to replace bounce-rate with a revamped and refreshed rearrangement of the relevant headline row, as well as the removal of the rarely revered bar chart.

Moreover, we repaired the functional retinue of tests to reinstate their rightful rapport