### PR TITLE
remove comparator, lighten queries

### DIFF
--- a/src/server/aggregations/ArticleComparator.js
+++ b/src/server/aggregations/ArticleComparator.js
@@ -2,20 +2,6 @@ import * as calculateInterval from '../utils/calculateInterval'
 
 export default function ArticleComparatorAggregation(query) {
   return {
-      page_views_since_publish: {
-        histogram: {
-          field: "time_since_publish",
-          interval: calculateInterval.minuteInterval(query.dateFrom, query.dateTo),
-          min_doc_count : 0
-        }
-      },
-      "page_views_over_time" : {
-        "date_histogram" : {
-          "field" : "view_timestamp",
-          interval : calculateInterval.interval(query.dateFrom, query.dateTo),
-          min_doc_count : 0
-        }
-      },
       avg_time_on_page : {
         avg : {
           field: "time_on_page"

--- a/src/server/aggregations/Articles.js
+++ b/src/server/aggregations/Articles.js
@@ -2,16 +2,9 @@ import * as calculateInterval from '../utils/calculateInterval'
 
 export default function ArticlesAggregation(query) {
   return {
-      page_views_since_publish: {
-        histogram: {
-          field: "time_since_publish",
-          interval: calculateInterval.minuteInterval(query.dateFrom, query.dateTo),
-          min_doc_count : 0
-        }
-      },  
-      "page_views_over_time" : {
-        "date_histogram" : {
-          "field" : "view_timestamp",
+      page_views_over_time : {
+        date_histogram : {
+          field : "view_timestamp",
           interval : calculateInterval.interval(query.dateFrom, query.dateTo),
           min_doc_count : 0
         }

--- a/src/server/formatters/Articles.js
+++ b/src/server/formatters/Articles.js
@@ -34,7 +34,7 @@ export default function formatData(data) {
   let [metaData, articleData, eventData, articleComparatorData, eventComparatorData] = data;
   let metaFields = ['title', 'uuid', 'author', 'published', 'published_human', 'genre', 'sections', 'topics']
   let articleFields = [
-    'pageViews', 'timeOnPage', 'readTimes', 'readTimesSincePublish', 'channels', 'uniqueVisitors',
+    'pageViews', 'timeOnPage', 'readTimes', 'channels', 'uniqueVisitors',
     'isSubscription', 'nextInternalUrl', 'internalReferrerTypes', 'internalReferrerUrls', 'isFirstVisit',
     'rfvCluster', 'userCohort', 'isLastPage', 'regions', 'countries', 'devices', 'socialReferrers',
     'referrerUrls', 'referrerNames', 'referrerTypes', 'top5TimeOnPage'
@@ -49,7 +49,7 @@ export default function formatData(data) {
     'articleCount', 'uniqueVisitors' , 'pageViews'
   ]
   let articleComparatorAverages = [
-    'readTimes', 'readTimesSincePublish', 'referrerTypes', 'socialReferrers', 'regions',
+    'referrerTypes', 'socialReferrers', 'regions',
     'isLastPage', 'userCohort', 'rfvCluster', 'isFirstVisit', 'internalReferrerTypes',
     'categoryAverageViewCount', 'categoryAverageUniqueVisitors'
   ]

--- a/src/server/utils/calculateInterval.js
+++ b/src/server/utils/calculateInterval.js
@@ -8,7 +8,7 @@ export function interval(dateFrom, dateTo) {
   if (span <= moment.duration(1, 'day')) {
     return 'hour';
   } else if (span <= moment.duration(1, 'week')) {
-    return 'day';
+    return 'hour';
   } else if (span <= moment.duration(6, 'month')) {
     return 'day';
   } else {

--- a/src/shared/components/SectionWhen.js
+++ b/src/shared/components/SectionWhen.js
@@ -29,31 +29,8 @@ export default class SectionWhen extends React.Component {
       return (<div></div>);
     }
 
-    let dataFormatter = new FormatData(this.props.data, this.props.comparatorData);
-    let [timeData, timeID, timeKeys] = dataFormatter.getMetric('readTimes', 'Article');
-    let [pubTimeData, pubTimeID, pubTimeKeys] = dataFormatter.getMetric('readTimesSincePublish', 'Article');
-
-    let readTimesChart = (this.props.renderReadTimes)
-      ? <LineChart
-        data={timeData}
-        keys={timeKeys}
-        category={timeID}
-        yLabel='Page Views'
-        xLabel='Time'
-        cols={12}
-        />
-      : null;
-    let timeSincePublishedChart = (this.props.renderTimeSincePublished)
-      ? <LineChart
-      data={pubTimeData}
-      keys={pubTimeKeys}
-      category={pubTimeID}
-      type='indexed'
-      yLabel='Page Views Since Publish date'
-      xLabel='Time since Published'
-      cols={12}
-      />
-      : null;
+    let dataFormatter = new FormatData(this.props.data);
+    let [timeData, timeID, timeKeys] = dataFormatter.getMetric('readTimes', 'Page Views');
 
     return (<ChunkWrapper component='sectionWhen'>
       <Row>
@@ -67,9 +44,13 @@ export default class SectionWhen extends React.Component {
                     <p><Text message='explanations.sectionWhen.articleViews' /></p>
                   </Popover>
                   }
-              >
+            >
               <span>
-                <Glyphicon glyph="question-sign" style={styles.infoIcon} aria-describedby="chart-description" />
+                <Glyphicon
+                  glyph="question-sign"
+                  style={styles.infoIcon}
+                  aria-describedby="chart-description"
+                />
               </span>
             </OverlayTrigger>
             <span >When did the users view the article?</span>
@@ -78,12 +59,14 @@ export default class SectionWhen extends React.Component {
       </Row>
       <Row>
         <Col xs={12}>
-          {readTimesChart}
-        </Col>
-      </Row>
-      <Row>
-        <Col xs={12}>
-          {timeSincePublishedChart}
+          <LineChart
+            data={timeData}
+            keys={timeKeys}
+            category={timeID}
+            yLabel='Page Views Since Publish date'
+            xLabel='Time since Published'
+            cols={12}
+          />
         </Col>
       </Row>
     </ChunkWrapper>);

--- a/test/components/sectionWhen.spec.js
+++ b/test/components/sectionWhen.spec.js
@@ -23,8 +23,8 @@ describe ('sectionWhen component', function() {
       const rows = section.props.children;
       const col = rows[1].props.children
       const lineChart = col.props.children.props
-      const metricLabel = 'Article'
-      const comparatorLabel = '\'testComp\' Average Article'
+      const metricLabel = 'Page Views'
+      const comparatorLabel = '\'testComp\' Page Views'
 
       expect(lineChart.data.length).to.equal(31)
       expect(lineChart.data[0][metricLabel]).to.equal(38)
@@ -32,36 +32,6 @@ describe ('sectionWhen component', function() {
       expect(lineChart.data[0].category).to.equal('2015-09-07T00:00:000Z')
       expect(lineChart.keys.length).to.equal(1)
       expect(lineChart.keys[0]).to.equal(metricLabel)
-    });
-
-    it ('comparator data', function() {
-      let section = createComponent(SectionWhen, {
-        renderReadTimes:true,
-        data: {
-          readTimes: fixtureData,
-          readTimesSincePublish: fixtureDataSincePublished
-        },
-        comparatorData: {
-          comparator: 'testComp',
-          readTimes: fixtureComparator
-        }
-      });
-      const rows = section.props.children;
-      const col = rows[1].props.children
-      const lineChart = col.props.children.props
-      const metricLabel = 'Article'
-      const comparatorLabel = '\'testComp\' Average Article'
-
-      expect(lineChart.data.length).to.equal(31)
-      expect(lineChart.data[0][metricLabel]).to.equal(38)
-      expect(lineChart.data[0][comparatorLabel]).to.equal(7)
-      expect(lineChart.data[0].category).to.equal('2015-09-07T00:00:000Z')
-      expect(lineChart.data[2][metricLabel]).to.equal(51)
-      expect(lineChart.data[2][comparatorLabel]).to.equal(16)
-      expect(lineChart.data[2].category).to.equal('2015-09-09T00:00:000Z')
-      expect(lineChart.keys.length).to.equal(2)
-      expect(lineChart.keys[0]).to.equal(metricLabel)
-      expect(lineChart.keys[1]).to.equal(comparatorLabel)
     });
 
   })
@@ -84,10 +54,9 @@ describe ('sectionWhen component', function() {
       const col = rows[1].props.children
       const lineChart = col.props.children.props
 
-      expect(lineChart.data.length).to.equal(31)
-      expect(lineChart.keys.length).to.equal(2)
-      expect(lineChart.keys[0]).to.equal('Article')
-      expect(lineChart.keys[1]).to.equal('\'testComp\' Average Article')
+      expect(lineChart.data.length).to.equal(0)
+      expect(lineChart.keys.length).to.equal(1)
+      expect(lineChart.keys[0]).to.equal('Page Views')
     })
 
     it('when there is no comparator data', function(){
@@ -106,7 +75,7 @@ describe ('sectionWhen component', function() {
 
       expect(lineChart.data.length).to.equal(31)
       expect(lineChart.keys.length).to.equal(1)
-      expect(lineChart.keys[0]).to.equal('Article')
+      expect(lineChart.keys[0]).to.equal('Page Views')
     })
 
 

--- a/test/esQueries/Articles.spec.js
+++ b/test/esQueries/Articles.spec.js
@@ -46,7 +46,7 @@ describe('Articles Query', () => {
     expect(ArticlesQuery(query).aggs.page_views_over_time.date_histogram.interval)
       .to.equal('hour');
   });
-  it('should return an interval of a day fror spans of a week or less', () => {
+  it('should return an interval of a hour fror spans of a week or less', () => {
     const query = {
       uuid: '123',
       dateFrom: '2015-01-01',
@@ -54,7 +54,7 @@ describe('Articles Query', () => {
       filters: {}
     };
     expect(ArticlesQuery(query).aggs.page_views_over_time.date_histogram.interval)
-      .to.equal('day');
+      .to.equal('hour');
   });
   it('should return an interval of a day for spans of a month or less', () => {
     const query = {

--- a/test/esQueries/Section.spec.js
+++ b/test/esQueries/Section.spec.js
@@ -58,7 +58,7 @@ describe('Sections Query', () => {
     expect(SectionsQuery(query).aggs.page_views_over_time.date_histogram.interval)
       .to.equal('hour');
   });
-  it('should return an interval of a day fror spans of a week or less', () => {
+  it('should return an interval of an hour for spans of a week or less', () => {
     const query = {
       uuid: '123',
       dateFrom: '2015-01-01',
@@ -67,7 +67,7 @@ describe('Sections Query', () => {
       section: 'test'
     };
     expect(SectionsQuery(query).aggs.page_views_over_time.date_histogram.interval)
-      .to.equal('day');
+      .to.equal('hour');
   });
   it('should return an interval of a day for spans of a month or less', () => {
     const query = {

--- a/test/esQueries/Topic.spec.js
+++ b/test/esQueries/Topic.spec.js
@@ -58,7 +58,7 @@ describe('Topics Query', () => {
     expect(TopicsQuery(query).aggs.page_views_over_time.date_histogram.interval)
       .to.equal('hour');
   });
-  it('should return an interval of a day fror spans of a week or less', () => {
+  it('should return an interval of an hour for spans of a week or less', () => {
     const query = {
       uuid: '123',
       dateFrom: '2015-01-01',
@@ -67,7 +67,7 @@ describe('Topics Query', () => {
       topic: 'test'
     };
     expect(TopicsQuery(query).aggs.page_views_over_time.date_histogram.interval)
-      .to.equal('day');
+      .to.equal('hour');
   });
   it('should return an interval of a day for spans of a month or less', () => {
     const query = {

--- a/test/formatters/Articles.spec.js
+++ b/test/formatters/Articles.spec.js
@@ -51,7 +51,6 @@ describe('Article Formatter', function() {
           'pageViews',
           'timeOnPage',
           'readTimes',
-          'readTimesSincePublish',
           'genre',
           'sections',
           'topics',

--- a/test/utils/calculateInterval.spec.js
+++ b/test/utils/calculateInterval.spec.js
@@ -5,7 +5,7 @@ describe('#calculateInterval', () => {
   describe('interval', () => {
     it('should calculate the interval correctly for two dates', () => {
       expect(calculateInterval.interval('2015-10-01', '2015-10-01')).to.equal('hour');
-      expect(calculateInterval.interval('2015-10-01', '2015-10-07')).to.equal('day');
+      expect(calculateInterval.interval('2015-10-01', '2015-10-07')).to.equal('hour');
       expect(calculateInterval.interval('2015-10-01', '2015-10-09')).to.equal('day');
       expect(calculateInterval.interval('2015-10-01', '2015-12-01')).to.equal('day');
     });


### PR DESCRIPTION
We remove comparator page views over time, both from the frontend and from the queries