### PR TITLE
48 Hour Realtime

### DIFF
--- a/src/server/aggregations/ArticleRealTime.js
+++ b/src/server/aggregations/ArticleRealTime.js
@@ -1,4 +1,9 @@
 export default function ArticlesRealtimeAggregation(query) {
+
+  const timespan = 'now-' + query.timespan + '/m';
+  let interval = '60s';
+  if (query.timespan === '48h') interval = '10m';
+
   return {
       links_clicked_last_hour: {
         filter: {
@@ -12,7 +17,7 @@ export default function ArticlesRealtimeAggregation(query) {
               {
                 range: {
                   event_timestamp: {
-                    gte: "now-1h/m"
+                    gte: timespan
                   }
                 }
               }
@@ -32,7 +37,7 @@ export default function ArticlesRealtimeAggregation(query) {
               {
                 range: {
                   event_timestamp: {
-                    gte: "now-1h/m"
+                    gte: timespan
                   }
                 }
               }
@@ -53,7 +58,7 @@ export default function ArticlesRealtimeAggregation(query) {
             must: {
               range: {
                 event_timestamp: {
-                  gte: "now-1h/m"
+                  gte: timespan
                 }
               }
             },
@@ -91,7 +96,7 @@ export default function ArticlesRealtimeAggregation(query) {
               {
                 range: {
                   event_timestamp: {
-                    gte: "now-1h/m"
+                    gte: timespan
                   }
                 }
               },
@@ -134,7 +139,7 @@ export default function ArticlesRealtimeAggregation(query) {
               {
                 range: {
                   event_timestamp: {
-                    gte: "now-1h/m"
+                    gte: timespan
                   }
                 }
               }
@@ -159,7 +164,7 @@ export default function ArticlesRealtimeAggregation(query) {
                {
                  range: {
                    event_timestamp: {
-                     gte: "now-1h/m"
+                     gte: timespan
                   }
                 }
               }
@@ -209,8 +214,7 @@ export default function ArticlesRealtimeAggregation(query) {
               {
                 range: {
                   event_timestamp : {
-                    from: query.dateFrom,
-                    to: query.dateTo
+                    gte: timespan
                   }
                 }
               }
@@ -221,7 +225,7 @@ export default function ArticlesRealtimeAggregation(query) {
           filtered : {
             date_histogram : {
               field: 'event_timestamp',
-              interval: '60s', // XXX this is likely to change
+              interval: interval, // XXX this is likely to change
               min_doc_count: 0,
               extended_bounds: {
                 min: query.dateFrom,
@@ -248,7 +252,7 @@ export default function ArticlesRealtimeAggregation(query) {
               {
                 range: {
                   event_timestamp: {
-                    gte: "now-1h/m"
+                    gte: timespan
                   }
                 }
               }
@@ -264,7 +268,7 @@ export default function ArticlesRealtimeAggregation(query) {
           time_on_page_histogram: {
             date_histogram: {
               field: 'event_timestamp',
-              interval: '60s',
+              interval: interval,
               min_doc_count: 0,
               extended_bounds: {
                 min: query.dateFrom,
@@ -277,38 +281,6 @@ export default function ArticlesRealtimeAggregation(query) {
                   field: "attention_time"
                 }
               }
-            }
-          }
-        }
-      },
-      live_page_views : {
-        filter: {
-          bool: {
-            must: [
-              {
-                term : {
-                  event_type : 'page'
-                }
-              },
-              {
-                term : {
-                  event_category: 'view'
-                }
-              },
-              {
-                range: {
-                  event_timestamp: {
-                    gte: "now-5m/m"
-                  }
-                }
-              }
-            ]
-          }
-        },
-        aggs : {
-          filtered: {
-            cardinality: {
-              field: 'visitor_id'
             }
           }
         }
@@ -346,7 +318,7 @@ export default function ArticlesRealtimeAggregation(query) {
           scroll_depth_last_hour_histogram: {
             date_histogram: {
               field: 'event_timestamp',
-              interval: '60s',
+              interval: interval,
               min_doc_count: 0,
               extended_bounds: {
                 min: query.dateFrom,

--- a/src/server/aggregations/ArticleRealTimeAll.js
+++ b/src/server/aggregations/ArticleRealTimeAll.js
@@ -1,4 +1,10 @@
 export default function ArticlesRealtimeAllAggregation(query) {
+
+  const timespan = 'now-' + query.timespan + '/m';
+  let interval = '60s';
+  if (query.timespan === '48h') interval = '10m';
+
+
   return {
     next_internal_url: {
       filter : {
@@ -17,7 +23,7 @@ export default function ArticlesRealtimeAllAggregation(query) {
             {
               range: {
                 event_timestamp: {
-                  gte: 'now-48h/m'
+                  gte: timespan
                 }
               }
             }
@@ -71,8 +77,7 @@ export default function ArticlesRealtimeAllAggregation(query) {
             {
               range: {
                 event_timestamp: {
-                  gte: 'now-48h/m',
-                  lt: 'now-30m/m'
+                  gte: timespan
                 }
               }
             },
@@ -93,7 +98,7 @@ export default function ArticlesRealtimeAllAggregation(query) {
         retention_last_hour_histogram: {
           date_histogram: {
             field: "event_timestamp",
-            interval: "60s",
+            interval: interval,
             min_doc_count: 0,
             extended_bounds: {
               min: query.dateFrom,
@@ -108,8 +113,6 @@ export default function ArticlesRealtimeAllAggregation(query) {
             }
           }
         }
-
-
       }
     }
   }

--- a/src/server/articlePoller.js
+++ b/src/server/articlePoller.js
@@ -2,15 +2,15 @@ import EventEmitter from 'events';
 import util from 'util';
 import {runArticleRealtimeQuery} from './esClient.js';
 import ArticleRealtimeDataFormatter from './formatters/ArticleRealtimeDataFormatter.js';
-import moment from 'moment';
 
-const FORMAT_START = 'YYYY-MM-DDTHH:mm:00.000[Z]';
-const FORMAT_END = 'YYYY-MM-DDTHH:mm:59.999[Z]';
-
-export default function ArticlePoller(uuid) {
+export default function ArticlePoller(uuid, timespan) {
   this.uuid = uuid;
+  this.timespan = timespan;
   // XXX make this like configurable and stuff ;_;
   this.interval = 5000;
+  if (this.timespan !== '1h') {
+    this.interval = 60 * 1000;
+  }
   EventEmitter.call(this);
   // then we immediately getArticleData which triggers
   // the polling
@@ -23,10 +23,10 @@ util.inherits(ArticlePoller, EventEmitter);
 // the updated data
 ArticlePoller.prototype.getArticleData = function() {
   const query = {
-    dateFrom: moment().subtract(1, 'hours').format(FORMAT_START),
-    dateTo: moment().format(FORMAT_END),
+    timespan: this.timespan,
     uuid: this.uuid
   }
+
   runArticleRealtimeQuery(query)
   .then(ArticleRealtimeDataFormatter)
   .then(results => {

--- a/src/server/esClient.js
+++ b/src/server/esClient.js
@@ -25,6 +25,7 @@ import LoggerFactory from './logger';
 import moment from 'moment';
 import calculateIndices from './utils/calculateIndices.js';
 import {calculateRealtimeIndices} from './utils/calculateIndices.js';
+import timestampParser from './utils/timestampParser';
 
 var client = elasticsearch.Client({
   hosts: process.env.ES_AWS_HOST,
@@ -138,11 +139,13 @@ export function runArticleRealtimeQuery(queryData) {
     return Promise.reject(queryError);
   }
 
-  if (!queryData.dateFrom || !queryData.dateTo) {
-    queryData.dateFrom = moment().subtract(1, 'hour').toISOString();
-    queryData.dateTo = moment().toISOString();
+  if (!queryData.timespan) {
+    queryData.timespan = '1h'
   }
 
+  const dates = timestampParser(queryData.timespan, moment());
+  Object.assign(queryData, dates);
+  
   let requests = [];
 
   requests.push(retrieveRealtimeArticleData(queryData));

--- a/src/server/esQueries/ArticleRealTime.js
+++ b/src/server/esQueries/ArticleRealTime.js
@@ -5,11 +5,11 @@ export default function ArticlesRealtimeESQuery(query) {
   assert.equal(typeof query, 'object',
     "argument 'query' should be an object");
 
-  assert.equal(typeof query.dateFrom, 'string',
-    "argument 'query' should contain a dateFrom string")
+  assert.equal(typeof query.timespan, 'string',
+    "argument 'query' should contain a timespan string")
 
-  assert.equal(typeof query.dateTo, 'string',
-    "argument 'query' should contain a dateTo string")
+  assert.ok(/(\d+)(\w+)/.test(query.timespan),
+    "argument query.timespan should be a timespan string (i.e. 48h)")
 
   assert.equal(typeof query.uuid, 'string',
     "argument 'query' should contain a 'uuid' string")

--- a/src/server/formatters/ArticleRealtimeDataFormatter.js
+++ b/src/server/formatters/ArticleRealtimeDataFormatter.js
@@ -38,7 +38,6 @@ export default function formatData(data) {
     'realtimeLinksClickedByCategory',
     'timeOnPageLastHour',
     'scrollDepthLastHour',
-    'livePageViews',
     'linksClickedLastHour',
     'socialSharesLastHour',
     'socialReferrersLastHour',

--- a/src/server/routers/api-routes.js
+++ b/src/server/routers/api-routes.js
@@ -69,8 +69,7 @@ function getCategoryData(req, res, next) {
 function getRealtimeArticleData(req, res, next) {
   const query = {
     uuid: decode(req.params.uuid),
-    dateFrom: req.query.dateFrom,
-    dateTo: req.query.dateTo
+    timespan: req.query.timespan
   }
   // XXX add cache 5 seconds
   esClient.runArticleRealtimeQuery(query)

--- a/src/server/routers/dataPreloader-routes.js
+++ b/src/server/routers/dataPreloader-routes.js
@@ -21,6 +21,15 @@ router.get(`/realtime/articles/:uuid(${UUID_REGEX})`, (req, res, next) => {
     });
 });
 
+router.get(`/realtime/articles/:uuid(${UUID_REGEX})/:timespan`, (req, res, next) => {
+  return getArticleRealtimeData(req, res)
+    .then(() => next())
+    .catch((err) => {
+      if (err.status) res.status(err.status);
+      next(err);
+    });
+});
+
 router.get(`/articles/:uuid(${UUID_REGEX})/:comparatorType(${COMPTYPE_REGEX})/:comparator`, (req, res, next) => {
   return getArticleData(req, res)
     .then(() => next())
@@ -120,7 +129,11 @@ function getArticleData(req, res){
 }
 
 function getArticleRealtimeData(req, res) {
-  return dataApiUtils.getArticleRealtimeData({uuid: decode(req.params.uuid)}, apiKey)
+  var query = {
+    uuid: decode(req.params.uuid),
+    timespan: req.params.timespan || '1h'
+  }
+  return dataApiUtils.getArticleRealtimeData(query, apiKey)
     .then((data) => {
       let totalPageViews = data.realtimePageViews.reduce((a, b) => { return a + b[1]; }, 0);
       let retentionRate = (data.retentionRate / totalPageViews) * 100 | 0;
@@ -137,7 +150,6 @@ function getArticleRealtimeData(req, res) {
           totalPageViews: totalPageViews,
           timeOnPage: data.timeOnPageLastHour,
           scrollDepth: data.scrollDepthLastHour,
-          livePageViews: data.livePageViews,
           realtimeNextInternalUrl: data.realtimeNextInternalUrl,
           linksClicked: data.linksClickedLastHour,
           realtimeLinksClickedByCategory: data.realtimeLinksClickedByCategory,
@@ -151,7 +163,8 @@ function getArticleRealtimeData(req, res) {
           externalReferrerLastHourUrls : data.referrerLastHourUrls,
           internalReferrerLastHourTypes: data.internalReferrerLastHourTypes,
           internalReferrerLastHourUrls: data.internalReferrerLastHourUrls,
-          userTypesLastHour: data.userTypesLastHour
+          userTypesLastHour: data.userTypesLastHour,
+          timespan: req.params.timespan || '1h'
         }
       };
       return res;

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -65,10 +65,13 @@ app.use('/landing/article/:uuid', ensureAuthenticated, (req, res) => {
     let publishDate = moment(data.initial_publish_date, 'YYYY-MM-DD');
     let now = moment();
 
-    if(moment(now).isAfter(publishDate, 'day')){
-      res.redirect(`/articles/${req.params.uuid}`);
-    } else {
+    const duration = moment.duration(now.diff(publishDate));
+    const hours = duration.asHours();
+
+    if(hours <= 48){
       res.redirect(`/realtime/articles/${req.params.uuid}`);
+    } else {
+      res.redirect(`/articles/${req.params.uuid}`);
     }
   });
 });

--- a/src/server/utils/calculateIndices.js
+++ b/src/server/utils/calculateIndices.js
@@ -1,6 +1,7 @@
 import moment from 'moment';
 
 const INDEX_FORMAT = 'YYYY-MM-DD';
+const RT_INDEX_FORMAT = 'YYYY-MM-DD-HH';
 
 export default function calculateIndices(query, ES_INDEX) {
   let dateFrom = moment(moment(query.dateFrom)).format(INDEX_FORMAT);
@@ -28,13 +29,25 @@ export default function calculateIndices(query, ES_INDEX) {
 
 
 export function calculateRealtimeIndices(query, ES_INDEX) {
-  let dateFrom = moment(query.dateFrom);
-  let dateTo = moment(query.dateTo);
-  return [dateFrom, dateTo].map((d) => {
-    d = moment(d);
-    return `${ES_INDEX}${d.format('YYYY-MM-DD-HH')}`
-  });
+  let dateFrom = moment(moment(query.dateFrom)).format(RT_INDEX_FORMAT);
+  let dateTo = moment(moment(query.dateTo)).format(RT_INDEX_FORMAT);
+
+  let indexStr = '';
+
+  let charF, charT;
+  let i = 0;
+  while (i < dateFrom.length) {
+    charF = dateFrom[i];
+    charT = dateTo[i];
+
+    if (charF === charT) {
+      indexStr += charF;
+    } else {
+      indexStr += '*';
+      break;
+    }
+    i++;
+  }
+  
+  return ES_INDEX + indexStr;
 }
-
-
-

--- a/src/server/utils/timestampParser.js
+++ b/src/server/utils/timestampParser.js
@@ -1,0 +1,11 @@
+import moment from 'moment';
+
+
+export default function timestampParser (timespan, baseDate) {
+  let [,amount, type] = /(\d+)(\w+)/.exec(timespan)
+
+  return {
+    dateFrom : moment(baseDate).subtract(amount, type).toISOString(),
+    dateTo : moment(baseDate).toISOString()
+  }
+}

--- a/src/server/utils/universalDataFormatter.js
+++ b/src/server/utils/universalDataFormatter.js
@@ -69,7 +69,6 @@ const fields = {
   internalReferrerLastHourUrls: {name: 'aggregations.internal_referrer_last_hour.urls', formatter: format},
   socialReferrersLastHour: {name: 'aggregations.referrer_last_hour.names', formatter: formatAndFilter, terms: ['Facebook', 'Twitter', 'Linked-In']},
   retentionRate: 'aggregations.retention_rate.filtered.value',
-  livePageViews: {name: 'aggregations.live_page_views.filtered.value', formatter: Math.round},
   timeOnPage: 'aggregations.avg_time_on_page.value',
   topicCount: {name: 'aggregations.topic_count', formatter: format},
   topicViews: {name: 'aggregations.topic_views', formatter: format},

--- a/src/shared/components/TabNav.js
+++ b/src/shared/components/TabNav.js
@@ -36,8 +36,8 @@ export default class TabNav extends React.Component {
 
   render() {
     let links = [
-      {title: "Last hour", url:`/realtime/articles/${this.props.uuid}`, type: "realtime"},
-      {title: "Last 48 hours", url:`/realtime/articles/${this.props.uuid}`, type: "realtime48"},
+      {title: "Last hour", url:`/realtime/articles/${this.props.uuid}`, type: "realtime1h"},
+      {title: "Last 48 hours", url:`/realtime/articles/${this.props.uuid}/48h`, type: "realtime48h"},
       {title: "Historical", url:`/articles/${this.props.uuid}`, type: "article", timePeriod: 24}
     ];
     let linkHtml = test(links, this.props.analyticsView, this.props.publishDate);
@@ -51,5 +51,3 @@ export default class TabNav extends React.Component {
     )
   }
 }
-
-

--- a/src/shared/handlers/ArticleRealtimeView.js
+++ b/src/shared/handlers/ArticleRealtimeView.js
@@ -88,7 +88,24 @@ class ArticleRealtimeView extends React.Component {
   }
 
   componentDidMount() {
-    ArticleRealtimeActions.subscribeToArticle(this.props.params.uuid);
+    const timespan = this.props.params.timespan || '1h';
+    ArticleRealtimeActions.subscribeToArticle({
+      uuid: this.props.params.uuid,
+      timespan: timespan
+    });
+  }
+
+  componentWillReceiveProps(nextProps) {
+     if (this.props.params.timespan !== nextProps.params.timespan) {
+       ArticleRealtimeActions.subscribeToArticle({
+         timespan: nextProps.params.timespan || '1h',
+         uuid: this.props.uuid,
+         previousArticle: {
+           timespan: this.props.timespan,
+           uuid: this.props.uuid
+         }
+       });
+     }
   }
 
   componentWillUnmount() {
@@ -265,14 +282,14 @@ class ArticleRealtimeView extends React.Component {
 
     /* Who are the users */
     let [userTypeData, userTypeID, userTypeKeys] = dataFormatter.getPCTMetric('userTypesLastHour', 'Article')
-
+    let timespan = this.props.timespan || "";
 
     return (
       <DocumentTitle title={title}>
       <div>
 
         <TabNav
-          analyticsView={this.props.route.analyticsView}
+          analyticsView={this.props.route.analyticsView + timespan}
           publishDate={this.props.published}
           uuid={this.props.uuid}
           />
@@ -492,7 +509,6 @@ ArticleRealtimeView.defaultProps = {
   pageViews: [],
   timeOnPage: null,
   scrollDepth: null,
-  livePageViews: null,
   totalPageViews: null,
   realtimeNextInternalUrl: [],
   linksClicked: null,
@@ -514,7 +530,8 @@ ArticleRealtimeView.defaultProps = {
   error: null,
   loading: false,
   uuid: null,
-  isLive: false
+  isLive: false,
+  timespan: '1h'
 };
 
 export default connectToStores(ArticleRealtimeView);

--- a/src/shared/routers/routes.js
+++ b/src/shared/routers/routes.js
@@ -62,6 +62,11 @@ export default (
       analyticsView="realtime"
     />
     <Route
+      path="realtime/articles/:uuid/:timespan"
+      component={ArticleRealtimeView}
+      analyticsView="realtime"
+    />
+    <Route
       path="*"
       name='404'
       component={Error404}

--- a/src/shared/utils/DataAPIUtils.js
+++ b/src/shared/utils/DataAPIUtils.js
@@ -44,6 +44,7 @@ let DataAPI = {
             url += "?apiKey=" + apiKey;
           }
           request.get(url)
+            .query({ timespan: query.timespan })
             .set('Accept', 'application/json')
             .end(handleResponse('ArticleRealtime', query, reject, resolve));
         });

--- a/test/components/tabNav.spec.js
+++ b/test/components/tabNav.spec.js
@@ -53,7 +53,7 @@ describe('The TabNav component', function() {
 
   it('Renders the tab with a active realtime tab', function() {
     let component = createComponent(TabNav, {
-      analyticsView: "realtime",
+      analyticsView: "realtime1h",
       publishDate: moment().subtract(32, 'h').toISOString(),
       uuid: "wewwe-23dsd3"
     });

--- a/test/esQueries/ArticlesRealtime.spec.js
+++ b/test/esQueries/ArticlesRealtime.spec.js
@@ -9,26 +9,13 @@ describe('#articlesRealtimeQuery', () => {
     let queryObject = ArticlesRealtimeQuery({
       dateFrom : "2015-11-24T10:15:00.000",
       dateTo : "2015-11-24T11:15:00.000",
+      timespan: '1h',
       uuid: "f02cca28-9028-11e5-bd82-c1fb87bef7af"
     })
     expect(queryObject).to.deep.equal(sampleQuery);
   })
   it('should throw if passed no query', () => {
     expect(() => ArticlesRealtimeQuery()).to.throw();
-  });
-  it('should throw if passed no dateFrom', () => {
-    const queryObject = {
-      dateTo : "2015-11-24T11:15:00.000",
-      uuid: "f02cca28-9028-11e5-bd82-c1fb87bef7af"
-    };
-    expect(() => ArticlesRealtimeQuery(queryObject)).to.throw();
-  });
-  it('should throw if passed no dateTo', () => {
-    const queryObject = {
-      dateFrom : "2015-11-24T10:15:00.000",
-      uuid: "f02cca28-9028-11e5-bd82-c1fb87bef7af"
-    };
-    expect(() => ArticlesRealtimeQuery(queryObject)).to.throw();
   });
   it('should throw if passed no uuid', () => {
     const queryObject = {
@@ -37,11 +24,16 @@ describe('#articlesRealtimeQuery', () => {
     };
     expect(() => ArticlesRealtimeQuery(queryObject)).to.throw();
   });
+  it('should throw if passed no timespan', () => {
+    const queryObject = {
+      uuid: 'woowowowowow'
+    };
+    expect(() => ArticlesRealtimeQuery(queryObject)).to.throw();
+  });
   it('should return the correct aggregators', () => {
     const query = {
       uuid: '123',
-      dateFrom: '2015-10-01',
-      dateTo: '2015-10-10'
+      timespan: '1h'
     };
     const queryJSON = ArticlesRealtimeQuery(query);
     const props = [

--- a/test/fixtures/realtimeQuery.js
+++ b/test/fixtures/realtimeQuery.js
@@ -215,8 +215,7 @@ export default {
             {
               range: {
                 event_timestamp: {
-                  from: "2015-11-24T10:15:00.000",
-                  to: "2015-11-24T11:15:00.000"
+                  gte: "now-1h/m"
                 }
               }
             }
@@ -285,38 +284,6 @@ export default {
                 field: "attention_time"
               }
             }
-          }
-        }
-      }
-    },
-    live_page_views : {
-      filter: {
-        bool: {
-          must: [
-            {
-              term : {
-                event_type : 'page'
-              }
-            },
-            {
-              term : {
-                event_category: 'view'
-              }
-            },
-            {
-              range: {
-                event_timestamp: {
-                  gte: "now-5m/m"
-                }
-              }
-            }
-          ]
-        }
-      },
-      aggs : {
-        filtered: {
-          cardinality: {
-            field: 'visitor_id'
           }
         }
       }

--- a/test/realtime/RealtimeServer.spec.js
+++ b/test/realtime/RealtimeServer.spec.js
@@ -44,7 +44,10 @@ describe('Realtime Server', () => {
       done();
     });
     client.on('error', done);
-    client.emit('subscribeToArticle', UUID);
+    client.emit('subscribeToArticle', {
+      uuid: UUID,
+      timespan: '1h'
+    });
   });
 
   it('should clean up pollers when there are no clients', (done) => {

--- a/test/utils/calculateIndices.spec.js
+++ b/test/utils/calculateIndices.spec.js
@@ -13,22 +13,18 @@ describe('#calculateRealtimeIndices', () => {
      dateTo : ('2015-01-01T21:00:00')
     }
 
-    expect(calculateRealtimeIndices(query, 'realtime-')).to.deep.equal([
-      'realtime-2015-01-01-20',
-      'realtime-2015-01-01-21',
-    ]);
+    expect(calculateRealtimeIndices(query, 'realtime-'))
+      .to.equal('realtime-2015-01-01-2*');
   })
 
   it('should return two indices if dates are in different hours', () => {
     const query = {
-     dateFrom : ('2015-01-01T20:15:00'),
+     dateFrom : ('2015-01-01T10:15:00'),
      dateTo : ('2015-01-01T21:15:00')
     }
 
-    expect(calculateRealtimeIndices(query, 'realtime-')).to.deep.equal([
-      'realtime-2015-01-01-20',
-      'realtime-2015-01-01-21'
-    ]);
+    expect(calculateRealtimeIndices(query, 'realtime-'))
+      .to.equal('realtime-2015-01-01-*');
   })
 
   it('should calculate dates between days correctly', () => {
@@ -37,10 +33,8 @@ describe('#calculateRealtimeIndices', () => {
      dateTo : ('2015-01-02T00:15:00')
     }
 
-    expect(calculateRealtimeIndices(query, 'realtime-')).to.deep.equal([
-      'realtime-2015-01-01-23',
-      'realtime-2015-01-02-00'
-    ]);
+    expect(calculateRealtimeIndices(query, 'realtime-'))
+      .to.equal('realtime-2015-01-0*');
   })
 });
 

--- a/test/utils/timestampParser.spec.js
+++ b/test/utils/timestampParser.spec.js
@@ -1,0 +1,18 @@
+import moment from 'moment';
+import timestampParser from '../../src/server/utils/timestampParser';
+import {expect} from 'chai';
+
+describe('timestampParser', () => {
+  it('should handle one hour', () => {
+    let baseDate = '2015-12-25T16:00:00.000Z';
+    let result = timestampParser('1h', baseDate);
+
+    expect(result.dateFrom).to.equal('2015-12-25T15:00:00.000Z')
+  });
+  it('should handle 48 hours', () => {
+    let baseDate = '2015-12-25T16:00:00.000Z';
+    let result = timestampParser('48h', baseDate);
+
+    expect(result.dateFrom).to.equal('2015-12-23T16:00:00.000Z')
+  });
+})


### PR DESCRIPTION
We can now do arbitrary durations of historical data

new route:
/realtime/article/:uuid/:timespan

where `timespan` is a `/\d+\w/` (i.e. `48h` or `1h`)

the default is `1h`

the route `/realtime/article/:uuid` still works, and sets a timespan of 1h

updated the `/landing` route to redirect to the correct duration

✌️🎈