### PR TITLE
Removes extra trigger of socket connection

### DIFF
--- a/src/shared/stores/ArticleRealtimeStore.js
+++ b/src/shared/stores/ArticleRealtimeStore.js
@@ -131,11 +131,7 @@ class ArticleRealtimeStore {
     setTimeout(() => {
       this.getInstance().loadArticleRealtimeData(query);
       this.setState(query);
-
-      // if (!this.getInstance().isLoading()) {
-      //   // Data not being fetched from server, go ahead and listen to web socket
-        this.connect();
-      // }
+      this.connect();
     }, 0);
   }
 
@@ -169,8 +165,6 @@ class ArticleRealtimeStore {
       userTypesLastHour: data.userTypesLastHour,
       lastUpdated: data.realtimePageViews.length ? data.realtimePageViews.slice(-1)[0][0] : null
     });
-
-    this.connect();
   }
 
   loadingData() {


### PR DESCRIPTION
Taking this out stops there being multiple unsubscribes from articles. It subscribes with xhr first time it loads, then subsequently with websockets when you move around realtime views