### PR TITLE
resolve event_date into event_timestamp for event queries

### DIFF
--- a/src/server/aggregations/ArticleEvents.js
+++ b/src/server/aggregations/ArticleEvents.js
@@ -9,16 +9,27 @@ export default function ArticleEventsAggregation(query) {
         min_doc_count : 0
       },
       aggs : {
-        "scroll_depth": {
-          "filter": {
-            "term": {
-              "event_type": "scroll"
+        scroll_depth: {
+          filter: {
+            bool : {
+              must : [
+                {
+                  term: {
+                    "event_type": "scroll"
+                  }
+                },
+                {
+                  term: {
+                    event_category: "depth"
+                  }
+                }
+              ]
             }
           },
-          "aggs": {
-            "average_scroll": {
-              "avg": {
-                "field": "event_value"
+          aggs: {
+            average_scroll: {
+              avg: {
+                field: "event_value"
               }
             }
           }
@@ -28,7 +39,7 @@ export default function ArticleEventsAggregation(query) {
     social_shares: {
       filter: {
         term: {
-          "event_type": "social share"
+          event_type: "social share"
         }
       },
       aggs: {
@@ -65,10 +76,21 @@ export default function ArticleEventsAggregation(query) {
         }
       }
     },
-    "scroll_depth": {
-      "filter": {
-        "term": {
-          "event_type": "scroll"
+    scroll_depth: {
+      filter: {
+        bool : {
+          must : [
+            {
+              term: {
+                "event_type": "scroll"
+              }
+            },
+            {
+              term: {
+                event_category: "depth"
+              }
+            }
+          ]
         }
       },
       "aggs": {

--- a/src/server/esClient.js
+++ b/src/server/esClient.js
@@ -145,7 +145,7 @@ export function runArticleRealtimeQuery(queryData) {
 
   const dates = timestampParser(queryData.timespan, moment());
   Object.assign(queryData, dates);
-  
+
   let requests = [];
 
   requests.push(retrieveRealtimeArticleData(queryData));

--- a/src/server/queries/eventQuery.js
+++ b/src/server/queries/eventQuery.js
@@ -15,7 +15,7 @@ export default function EventQuery(query){
           must: [
             {
               range: {
-                event_date: {
+                event_timestamp: {
                   from: query.dateFrom,
                   to: query.dateTo
                 }

--- a/test/queries/eventQuery.spec.js
+++ b/test/queries/eventQuery.spec.js
@@ -48,7 +48,7 @@ describe('Event Query', () => {
               must:[
                 {
                   range:{
-                    event_date:{
+                    event_timestamp:{
                       from:"11-mar-2014",
                       to:"12-mar-2015"
                     }
@@ -78,7 +78,7 @@ describe('Event Query', () => {
               must:[
                 {
                   range:{
-                    event_date:{
+                    event_timestamp:{
                       from:"11-mar-2014",
                       to:"12-mar-2015"
                     }


### PR DESCRIPTION
we were using event_date for the events queries, which did not match as opposed to timestamp. now the results fit with kibana.