### PR TITLE
Add a scroll To Top functionality on route entering

### DIFF
--- a/src/shared/components/SectionModifier.js
+++ b/src/shared/components/SectionModifier.js
@@ -45,11 +45,10 @@ export default class Modifier extends React.Component {
 
   constructor(props) {
     super(props);
-    this.state = {};
-    this.setState({
+    this.state = {
       isSectionOrTopic : ['sections', 'topics'].indexOf(this.props.category) >= 0,
       isGlobalFTComparator : this.props.comparatorQuery.comparatorType === 'global'
-    });
+    };
   }
 
   handleDateRangeChange (dates) {

--- a/src/shared/routers/routes.js
+++ b/src/shared/routers/routes.js
@@ -1,6 +1,6 @@
 import { Route, Redirect } from "react-router";
 import React from "react";
-
+import isBrowser from "../utils/isBrowser";
 import AppController from "../controllers/AppController";
 import Search from "../handlers/Search";
 import Error404 from "../handlers/404";
@@ -11,25 +11,34 @@ import ArticleRealtimeView from '../handlers/ArticleRealtimeView';
 
 import HistoricalAnalyticsView from '../handlers/HistoricalAnalyticsView';
 
+function scrollToTop() {
+  if (isBrowser()) {
+    window.scrollTop = 0;
+  }
+}
 
 export default (
-  <Route component={ AppController } >
+  <Route component={AppController}>
     <Route
       path="/"
+      onEnter={scrollToTop}
       component={Search}
     />
     <Route
       path="playground"
+      onEnter={scrollToTop}
       component={Playground}
     >
       <Route
         path=":componentName"
+        onEnter={scrollToTop}
         component={PlaygroundLoader}
       />
     </Route>
     <Route
       path="articles/:uuid/:comparatorType/:comparator"
       component={HistoricalAnalyticsView}
+      onEnter={scrollToTop}
       analyticsView="article"
     />
     <Redirect from="articles/:uuid"
@@ -37,42 +46,50 @@ export default (
     />
     <Route
       path="sections/:section"
+      onEnter={scrollToTop}
       component={HistoricalAnalyticsView}
       analyticsView="section"
     />
     <Route
       path="sections/:section/:comparatorType/:comparator"
+      onEnter={scrollToTop}
       component={HistoricalAnalyticsView}
       analyticsView="section"
     />
     <Route
       path="topics/:topic"
+      onEnter={scrollToTop}
       component={HistoricalAnalyticsView}
       analyticsView="topic"
     />
     <Route
       path="topics/:topic/:comparatorType/:comparator"
+      onEnter={scrollToTop}
       component={HistoricalAnalyticsView}
       analyticsView="topic"
     />
     <Route
       path="pickoftheday"
+      onEnter={scrollToTop}
       component={TopArticlesView}
       analyticsView="pickoftheday"
     />
     <Route
       path="realtime/articles/:uuid"
+      onEnter={scrollToTop}
       component={ArticleRealtimeView}
       analyticsView="realtime"
     />
     <Route
       path="realtime/articles/:uuid/:timespan"
+      onEnter={scrollToTop}
       component={ArticleRealtimeView}
       analyticsView="realtime"
     />
     <Route
       path="*"
       name='404'
+      onEnter={scrollToTop}
       component={Error404}
     />
   </Route>


### PR DESCRIPTION
when we enter a route, we will scroll the page to the top in order to avoid journalists from getting lost in the page, saving them valuable seconds of scrolling on their otherwise busy lives.

Also fixed the constructor of the `SectionModifier.js` where @radiodario changed the initial state into a `setState` call, inadvertently creating a no-op and being a general muppet.