### PR TITLE
Article List Queries, Section view table

### DIFF
--- a/src/server/esClient.js
+++ b/src/server/esClient.js
@@ -59,11 +59,11 @@ var proxySearch = function(type, request, callback) {
   return client[type].call(client, request, wrappedCallback);
 };
 
-export function getIndicies(indicies, h = 'health,index,docs.count,store.size,tm'){
+export function getIndicies(indices, h = 'health,index,docs.count,store.size,tm'){
   return new Promise((resolve, reject) => {
     client.cat.indices({
       h: h,
-      index: indicies
+      index: indices
     }, function(e, response){
       e && reject(e)
       !e && resolve(response)
@@ -137,6 +137,20 @@ export function runSectionQuery(queryData) {
   }
   return retrieveSectionData(queryData)
     .then((sectionData) => { return sectionData });
+}
+
+export function runArticleList(queryData) {
+  return retrieveArticleList(queryData)
+  .then((articleList) => {
+    return articleList;
+  });
+}
+
+export function runRealtimeArticleList(queryData) {
+  return retrieveRealtimeArticleList(queryData)
+  .then((articleList) => {
+    return articleList;
+  });
 }
 
 export function runTopicQuery(queryData) {
@@ -259,6 +273,42 @@ function retrieveArticleData(queryData){
     });
   })
 }
+
+import ArticleListQuery from './esQueries/ArticleList';
+function retrieveArticleList(queryData) {
+  return new Promise((resolve, reject) => {
+    const query = {
+      index: calculateIndices(queryData, process.env.ES_INDEX_ROOT),
+      body: ArticleListQuery(queryData)
+    };
+
+    client.search(query, (error, response) => {
+      if (error) {
+        return reject(error);
+      }
+      resolve(response);
+    });
+
+  });
+}
+
+import RealtimeArticleListQuery from './esQueries/RealtimeArticleList';
+function retrieveRealtimeArticleList(queryData) {
+  return new Promise((resolve, reject) => {
+    const query = {
+      index: calculateIndices(queryData, process.env.ES_REALTIME_INDEX_ROOT),
+      body: RealtimeArticleListQuery(queryData)
+    };
+
+    client.search(query, (error, response) => {
+      if (error) {
+        return reject(error);
+      }
+      resolve(response);
+    })
+  });
+}
+
 
 function retrieveSectionData(queryData){
   return new Promise((resolve, reject) => {

--- a/src/server/esQueries/ArticleComparator.js
+++ b/src/server/esQueries/ArticleComparator.js
@@ -1,5 +1,4 @@
 import assert from 'assert';
-import moment from 'moment';
 import ArticleComparatorAggregation from '../aggregations/ArticleComparator'
 import ArticleComparatorQuery from '../queries/articleComparatorQuery'
 

--- a/src/server/esQueries/ArticleList.js
+++ b/src/server/esQueries/ArticleList.js
@@ -1,0 +1,90 @@
+import assert from 'assert';
+
+export default function ArticleListQuery(query) {
+
+  assert.equal(typeof query, 'object',
+    "argument 'query' should be an object");
+
+  const termField = `primary_${query.type}`
+  const esQuery = {
+    query: {
+      bool: {
+        must: [
+          {
+            match: {
+              [termField] : query.value
+            }
+          },
+          {
+            range: {
+              initial_publish_date: {
+                from: query.dateFrom,
+                to: query.dateTo
+              }
+            }
+          }
+        ]
+      }
+    },
+    size: 0,
+    aggs: {
+      articles: {
+        terms: {
+          field: 'article_uuid',
+          size: 1000000,
+          order: {
+            'initial_publish_date': 'desc'
+          }
+        },
+        aggs: {
+          initial_publish_date: {
+            max: {
+              field: "initial_publish_date"
+            }
+          },
+          metadata: {
+            top_hits: {
+              sort: [
+                {
+                  article_uuid: {
+                    order: 'desc'
+                  }
+                }
+              ],
+              _source: {
+                include: [
+                  "title",
+                  "article_uuid",
+                  "primary_section",
+                  "initial_publish_date"
+                ]
+              },
+              size: 1
+            }
+          },
+          avg_time_on_page: {
+            avg: {
+              field: "time_on_page"
+            }
+          },
+          retention: {
+            filter: {
+              bool: {
+                must: [
+                  {
+                    term: {
+                      is_last_page: false
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  };
+
+  return esQuery;
+
+}

--- a/src/server/esQueries/RealtimeArticleList.js
+++ b/src/server/esQueries/RealtimeArticleList.js
@@ -1,0 +1,104 @@
+import assert from 'assert';
+
+export default function RealitmeArticleListQuery(query) {
+  assert.equal(typeof query, 'object',
+    "argument 'query' must be an object");
+
+  const termField = `primary_${query.type}`;
+  const esQuery = {
+    query: {
+      bool: {
+        must: [
+          {
+            range: {
+              event_timestamp: {
+                gte: 'now-1d/d'
+              }
+            }
+          },
+          {
+            match: {
+              [termField] : query[query.type]
+            }
+          }
+        ]
+      }
+    },
+    size: 0,
+    aggs: {
+      articles: {
+        terms: {
+          field: 'article_uuid'
+        },
+        aggs: {
+          metadata: {
+            top_hits: {
+              sort: [
+                {
+                  article_uuid: {
+                    order: 'desc'
+                  }
+                }
+              ],
+              _source: {
+                include: [
+                  "title",
+                  "article_uuid",
+                  "primary_section",
+                  "initial_publish_date"
+                ]
+              },
+              size: 1
+            }
+          },
+          page_views: {
+            filter: {
+              bool: {
+                must: [
+                  {
+                    term: {
+                      event_type: 'page'
+                    }
+                  },
+                  {
+                    term: {
+                      event_type: 'view'
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          time_on_page: {
+            filter: {
+              bool: {
+                must: [
+                  {
+                    term: {
+                      event_type: 'page'
+                    }
+                  },
+                  {
+                    term: {
+                      event_category: 'supplement'
+                    }
+                  }
+                ]
+              }
+            },
+            aggs: {
+              average: {
+                avg: {
+                  field: 'attention_time'
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  };
+
+  return esQuery;
+
+}

--- a/src/server/esQueries/Sections.js
+++ b/src/server/esQueries/Sections.js
@@ -1,6 +1,7 @@
 import assert from 'assert';
-import SectionAggregation from '../aggregations/Sections'
-import SectionQuery from '../queries/sectionQuery'
+import SectionAggregation from '../aggregations/Sections';
+import SectionQuery from '../queries/sectionQuery';
+import ArticleListQuery from './ArticleList';
 
 export default function SectionESQuery(query) {
 
@@ -24,5 +25,10 @@ export default function SectionESQuery(query) {
     query : sectionQuery,
     aggs: SectionAggregation(query)
   };
+
+  let articleListQuery = ArticleListQuery(query);
+
+  Object.assign(esQuery.aggs, articleListQuery.aggs);
+
   return esQuery
 }

--- a/src/server/formatters/ArticleListFormatter.js
+++ b/src/server/formatters/ArticleListFormatter.js
@@ -1,0 +1,13 @@
+export default function(results) {
+  return results.aggregations.articles.buckets.map((r) => {
+    const source = r.metadata.hits.hits[0]._source;
+    return {
+      article_uuid: source.article_uuid,
+      title: source.title,
+      initial_publish_date: source.initial_publish_date,
+      page_views: r.metadata.hits.total,
+      time_on_page: r.avg_time_on_page.value,
+      retention_rate: r.retention.doc_count / r.metadata.hits.total
+    };
+  });
+}

--- a/src/server/formatters/RealtimeArticleListFormatter.js
+++ b/src/server/formatters/RealtimeArticleListFormatter.js
@@ -1,0 +1,13 @@
+export default function(results) {
+  return results.aggregations.articles.buckets.map((r) => {
+    const source = r.metadata.hits.hits[0]._source;
+    return {
+      article_uuid: source.article_uuid,
+      title: source.title,
+      initial_publish_date: source.initial_publish_date,
+      page_views: r.page_views.doc_count,
+      time_on_page: r.time_on_page.average.value
+    };
+  });
+}
+

--- a/src/server/formatters/Sections.js
+++ b/src/server/formatters/Sections.js
@@ -1,5 +1,6 @@
 import assert from 'assert';
 import getField from '../utils/universalDataFormatter';
+import articleListFormatter from './ArticleListFormatter';
 
 export default function SectionDataFormatter(data) {
   try {
@@ -33,6 +34,8 @@ export default function SectionDataFormatter(data) {
       ];
       metaFields.forEach(f => { results[f] = getField(metaData, f)})
       sectionFields.forEach(f => { results[f] = getField(sectionData, f)})
+
+      results.articleList = articleListFormatter(sectionData);
 
       let comparatorResults = {};
       if (compMetaData) {

--- a/src/server/queries/sectionComparatorQuery.js
+++ b/src/server/queries/sectionComparatorQuery.js
@@ -39,13 +39,17 @@ export default function sectionComparatorQuery(query){
 
   let matchAll = {
     bool: {
-      must: [matchDates, matchSection],
+      must: [matchDates, matchSection]
     }
   }
 
   let filtered = {
     query : matchAll,
     filter : filter
+  }
+
+  if (query.comparator === 'FT'){
+    filtered.query.bool.must = [matchDates];
   }
 
   return {

--- a/src/server/queries/sectionQuery.js
+++ b/src/server/queries/sectionQuery.js
@@ -35,10 +35,6 @@ export default function sectionQuery(query){
     filter : filter
   }
 
-  if (query.comparator === 'FT'){
-    filtered.query.bool.must = [matchDates];
-  }
-
   return {
     "filtered" : filtered
   };

--- a/src/shared/components/ArticleList.js
+++ b/src/shared/components/ArticleList.js
@@ -1,0 +1,151 @@
+import React from 'react';
+import Table from './Table';
+import Button from 'react-bootstrap/lib/Button';
+import ChunkWrapper from './ChunkWrapper';
+import Row from 'react-bootstrap/lib/Row';
+import Col from 'react-bootstrap/lib/Col';
+import d3 from 'd3';
+import moment from 'moment';
+import {Link} from 'react-router';
+import convert from '../utils/convertUnits';
+import GlyphIcon from 'react-bootstrap/lib/Glyphicon';
+
+export default class ArticleList extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state =  {
+      showAllArticles: false,
+      page: 0,
+      articlesPerPage: 10,
+      sortIndex: 1,
+      sortDirection: -1
+    };
+  }
+
+  toggleAllArticles() {
+    this.setState({
+      showAllArticles: !this.state.showAllArticles
+    });
+  }
+
+  handleSort(name, index) {
+    if (this.state.sortIndex === index) {
+      return this.setState({
+        sortDirection: -1 * this.state.sortDirection
+      });
+    }
+    this.setState({
+      sortIndex: index,
+      sortDirection : -1
+    });
+  }
+
+  render() {
+    const numArticles = this.props.articleList.length;
+    const buttText = this.state.showAllArticles ? 'Show only 10 articles' : `Show all ${numArticles} articles`;
+    const clickHandler = this.toggleAllArticles.bind(this);
+    const lastArticleIndex = this.state.showAllArticles ? numArticles - 1 : 10;
+
+    const formatter = d3.format(',n');
+
+    const headersForSorting = [
+      'title',
+      'initial_publish_date',
+      'page_views',
+      'retention_rate',
+      'time_on_page'
+    ];
+    // this list contains the data to sort on
+    const articleList = this.props.articleList
+    .sort((a, b) => {
+      const propName = headersForSorting[this.state.sortIndex];
+      const aval = a[propName];
+      const bval = b[propName];
+      if (this.state.sortDirection > 0) {
+        if (aval > bval) return 1
+        if (aval < bval) return -1
+      } else {
+        if (bval > aval) return 1
+        if (bval < aval) return -1
+      }
+      return 0
+    })
+    .slice(0, lastArticleIndex).map((d, i) => {
+      let linkUrl = '/articles/' + d.article_uuid;
+      const publishedMoment = moment(d.initial_publish_date);
+      const now = moment();
+      const diff = now.diff(publishedMoment, 'hours');
+      let link;
+      if (diff < 24) {
+        linkUrl = '/realtime' + linkUrl;
+        link = <Link to={linkUrl}>{d.title}</Link>;
+      } else if (diff < 48) {
+        linkUrl = '/realtime' + linkUrl + '/48h';
+        link = <Link to={linkUrl}>{d.title}</Link>;
+      } else {
+        link = <a href={linkUrl}>{d.title}</a>;
+      }
+
+      const pageViews = formatter(d.page_views);
+      const retRate = Math.floor(d.retention_rate * 100) + '%';
+      const timeOnPage = convert.time(d.time_on_page)[0];
+      return [
+        i+1,
+        link,
+        publishedMoment.format('MMM D, YYYY HH:mm'),
+        pageViews,
+        retRate,
+        timeOnPage
+      ];
+    });
+
+    const articleListHeaders = [
+      '', 'Article', 'Publish Date',
+      'Page Views', 'Retention Rate',
+      'Time on Page'
+    ];
+
+    const sortDirectionIndicator = (this.state.sortDirection > 0)
+      ? <GlyphIcon glyph="arrow-up"/>
+      : <GlyphIcon glyph="arrow-down"/>
+
+    const sortedEl = (
+      <span>
+        {articleListHeaders[this.state.sortIndex+1]}
+        {sortDirectionIndicator}
+      </span>
+    );
+
+    articleListHeaders[this.state.sortIndex+1] = sortedEl;
+
+    const sortHandler = this.handleSort.bind(this);
+    return (
+      <ChunkWrapper component="ArticleList">
+        <Row>
+          <Col xs={12}>
+            <h3>Stories</h3>
+          </Col>
+        </Row>
+        <Row>
+          <Col xs={12}>
+            <Table
+              rows={articleList}
+              headers={articleListHeaders}
+              onHeaderClick={sortHandler}
+              sortable
+            />
+          </Col>
+        </Row>
+        <Row>
+          <Col xs={12}>
+            <Button onClick={clickHandler}>
+              {buttText}
+            </Button>
+          </Col>
+        </Row>
+      </ChunkWrapper>
+    );
+  }
+
+}

--- a/src/shared/components/Header.js
+++ b/src/shared/components/Header.js
@@ -1,9 +1,6 @@
 import React from 'react';
-import Col from 'react-bootstrap/lib/Col';
-import Row from 'react-bootstrap/lib/Row';
 import responsiveStyles from '../utils/responsiveStyles';
 import Glyphicon from 'react-bootstrap/lib/Glyphicon';
-import ChunkWrapper from './ChunkWrapper.js';
 
 const componentStyles = {
   'default': {

--- a/src/shared/components/SectionWhen.js
+++ b/src/shared/components/SectionWhen.js
@@ -75,3 +75,7 @@ export default class SectionWhen extends React.Component {
     </ChunkWrapper>);
   }
 }
+
+SectionWhen.defaultProps = {
+  lastPublishDates: []
+}

--- a/src/shared/components/SingleMetric.js
+++ b/src/shared/components/SingleMetric.js
@@ -5,45 +5,8 @@ import assign from 'object-assign';
 import Popover from 'react-bootstrap/lib/Popover';
 import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
 import Button from 'react-bootstrap/lib/Button';
+import convert from '../utils/convertUnits';
 
-function getPercentageDifference (compared , comparator) {
-  return ((Math.abs(compared-comparator)/ comparator) * 100) | 0;
-}
-
-function checkSignClass (x) {
-  return (x < 0) ? 'down' : 'up';
-}
-
-let convert = {
-  secondsToMinutes: (seconds) => {
-    seconds = Math.abs(seconds)
-    let metricMinutes = Math.floor(seconds / 60);
-    let metricSeconds = Math.floor(seconds - metricMinutes * 60);
-    return {minutes: metricMinutes, seconds: metricSeconds};
-  },
-  percentageDifference: (metric, comparatorMetric) => {
-    if (!comparatorMetric) return [null, null]
-    let comparatorDifference = getPercentageDifference(metric, comparatorMetric);
-    let differenceSign = checkSignClass(metric - comparatorMetric);
-    return [differenceSign, comparatorDifference + '%'];
-  },
-  time: (metric, comparatorMetric)=> {
-    let convertedMetric = convert.secondsToMinutes(metric);
-    let transformMetric = convertedMetric.minutes + 'm ' + convertedMetric.seconds + 's';
-    let [differenceSign, transformComparator] = convert.percentageDifference(metric, comparatorMetric)
-    return [transformMetric, differenceSign, transformComparator];
-  },
-  integer:  (metric, comparatorMetric)=>{
-    let transformMetric = (metric || 0).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",") // Add commas to output
-    let [differenceSign, transformComparator] = convert.percentageDifference(metric, comparatorMetric)
-    return [transformMetric, differenceSign, transformComparator];
-  },
-  percentage:  (metric, comparatorMetric)=>{
-    let transformMetric = (metric || 0) +"%";
-    let [differenceSign, transformComparator] = convert.percentageDifference(metric, comparatorMetric)
-    return [transformMetric, differenceSign, transformComparator];
-  }
-};
 
 export default class SingleMetric extends ReactCSS.Component {
   constructor(props) {
@@ -166,7 +129,8 @@ export default class SingleMetric extends ReactCSS.Component {
             style={assign(this.styles().comparatorSymbol, compColor)}
           />
           <span
-            style={assign(this.styles().comparatorValue, compColor)}>
+            style={assign(this.styles().comparatorValue, compColor)}
+          >
             {transfromComparator}
           </span>
         </span>

--- a/src/shared/components/Table.js
+++ b/src/shared/components/Table.js
@@ -1,54 +1,80 @@
 import React from 'react';
 import Table from 'react-bootstrap/lib/Table';
 
-function createDataRows (props) {
-  return props.rows.map((d, i) => {
-    let dataObjectKeys = props.rows.length > 0 ? Object.keys(props.rows[0]) : Object.keys(d);
-    let cells = dataObjectKeys.map((k, j) => {
-      return (
-        <td key={j}>
-          {d[k]}
-        </td>
-      );
-    });
-    return (
-      <tr key={i}>
-        {cells}
-      </tr>
-    );
-  });
-}
 
 export default class DataTable extends React.Component {
 
-  render() {
-      let heads = this.props.headers.map((d, i) => {
+  createDataRows() {
+    let rows = this.props.rows;
+
+    if (!rows.length) {
+      return [[<tr key={0}><td>{'No Data Available'}</td></tr>]];
+    }
+
+    return rows.map((d, i) => {
+      let dataObjectKeys = rows.length > 0 ? Object.keys(rows[0]) : Object.keys(d);
+      let cells = dataObjectKeys.map((k, j) => {
         return (
-          <th key={i}>
-            {d}
-          </th>
+          <td key={j}>
+            {d[k]}
+          </td>
         );
       });
-
-      let rows = this.props.rows.length === 0 ? [[<tr><td>{'No Data Available'}</td></tr>]] : createDataRows(this.props);
-
       return (
-        <Table data-component="table">
-          <thead>
-          <tr>
-            {heads}
-          </tr>
-          </thead>
-
-          <tbody>
-            {rows}
-          </tbody>
-        </Table>
+        <tr key={i}>
+          {cells}
+        </tr>
       );
+    });
+  }
+
+  handleHeaderClick(name, key) {
+    // only sort from second header onwards
+    if (key)
+      this.props.onHeaderClick(name, key-1);
+  }
+
+  render() {
+    let heads = this.props.headers.map((d, i) => {
+      const handler = this.handleHeaderClick.bind(this, d, i);
+      const style = {};
+      if (this.props.sortable && i) {
+        style.cursor = 'pointer'
+      }
+      return (
+        <th key={i}
+          style={style}
+          onClick={this.props.sortable ? handler : null}
+        >
+          {d}
+        </th>
+      );
+    });
+
+    let rows = this.createDataRows();
+
+    return (
+      <Table
+        responsive
+        condensed
+        data-component="table"
+      >
+        <thead>
+        <tr>
+          {heads}
+        </tr>
+        </thead>
+
+        <tbody>
+          {rows}
+        </tbody>
+      </Table>
+    );
   }
 }
 
 DataTable.defaultProps = {
   headers : ['Default 1', 'Default 2'],
-  rows : [[3 , 4], [5 , 6], [7 , 8]],
+  onHeaderClick: () => {},
+  rows : [[3 , 4], [5 , 6], [7 , 8]]
 };

--- a/src/shared/handlers/HistoricalAnalyticsView.js
+++ b/src/shared/handlers/HistoricalAnalyticsView.js
@@ -5,6 +5,7 @@ import AnalyticsStore from '../stores/AnalyticsStore';
 import Messaging from '../components/Messaging';
 import ErrorHandler from '../components/ErrorHandler';
 import assign from 'object-assign';
+import alt from '../alt';
 
 import ArticleView from "./ArticleView";
 import SectionView from "./SectionView";
@@ -32,47 +33,55 @@ class HistoricalAnalyticsView extends React.Component {
     return AnalyticsStore.getState();
   }
 
-  componentWillMount() {
-    if (this.props.error) return; // in an error case, there's no valid query
-
-    switch (this.props.route.analyticsView) {
+  updateQuery(props) {
+    switch (props.route.analyticsView) {
       case VIEW_TYPE_ARTICLE:
         AnalyticsActions.updateQuery({
-          uuid : decode(this.props.params.uuid),
+          uuid : decode(props.params.uuid),
           type: 'article',
-          comparatorType: decode(this.props.params.comparatorType),
-          comparator: decode(this.props.params.comparator)
+          comparatorType: decode(props.params.comparatorType),
+          comparator: decode(props.params.comparator)
         });
         break;
       case VIEW_TYPE_SECTION:
         AnalyticsActions.updateQuery({
-          section: decode(this.props.params.section),
+          section: decode(props.params.section),
           type: 'section',
-          comparator: decode(this.props.params.comparator),
-          comparatorType: decode(this.props.params.comparatorType)
+          comparator: decode(props.params.comparator),
+          comparatorType: decode(props.params.comparatorType)
         });
         break;
       case VIEW_TYPE_TOPIC:
         AnalyticsActions.updateQuery({
-          topic: decode(this.props.params.topic),
+          topic: decode(props.params.topic),
           type: 'topic',
-          comparator: decode(this.props.params.comparator),
-          comparatorType: decode(this.props.params.comparatorType)
+          comparator: decode(props.params.comparator),
+          comparatorType: decode(props.params.comparatorType)
         });
         break;
     }
+
+  }
+
+  componentWillMount() {
+    if (this.props.error) return; // in an error case, there's no valid query
+    this.updateQuery(this.props);
   }
 
   componentWillReceiveProps(newProps) {
     // Update the query if the comparator changes
     if (this.props.params.comparator !== newProps.params.comparator
       || this.props.params.comparatorType !== newProps.params.comparatorType) {
-        AnalyticsActions.updateQuery(assign(
-          {},
-          this.props.query,
-          { comparator: newProps.params.comparator, comparatorType: newProps.params.comparatorType }
-        ));
+      AnalyticsActions.updateQuery(assign(
+        {},
+        this.props.query,
+        { comparator: newProps.params.comparator, comparatorType: newProps.params.comparatorType }
+      ));
       }
+    if (this.props.route.analyticsView !== newProps.route.analyticsView) {
+      alt.recycle(AnalyticsStore);
+      this.updateQuery(newProps);
+    }
   }
 
   componentDidMount() {
@@ -83,6 +92,7 @@ class HistoricalAnalyticsView extends React.Component {
 
   componentWillUnmount() {
     AnalyticsActions.destroy();
+    alt.recycle(AnalyticsStore);
   }
 
   render() {

--- a/src/shared/handlers/SectionView.js
+++ b/src/shared/handlers/SectionView.js
@@ -4,7 +4,6 @@ import Col from 'react-bootstrap/lib/Col';
 import Row from 'react-bootstrap/lib/Row';
 import FormatData from "../utils/formatData";
 import FeatureFlag from '../utils/featureFlag';
-
 import Header from '../components/Header';
 import Messaging from '../components/Messaging';
 import SectionModifier from '../components/SectionModifier';
@@ -15,8 +14,8 @@ import SectionWho from "../components/SectionWho";
 import SectionWhere from "../components/SectionWhere";
 import SectionHeadlineStats from "../components/SectionHeadlineStats";
 import TabNav from '../components/TabNav';
-
 import ChunkWrapper from "../components/ChunkWrapper";
+import ArticleList from '../components/ArticleList';
 
 class SectionView extends React.Component {
 
@@ -70,7 +69,8 @@ class SectionView extends React.Component {
     let [socialData, socialID, socialKeys] = dataFormatter.getPCTMetric('socialReferrers', 'Views');
     let [internalData, internalID, internalKeys] = dataFormatter.getPCTMetric('internalReferrerTypes', 'Views');
 
-    let headlineStats = {
+
+    const headlineStats = {
       topicsCovered: {
         metricType: 'integer',
         label: 'Topics Covered',
@@ -93,19 +93,28 @@ class SectionView extends React.Component {
 
     let links = [
       {
-        title: "Today",
+        title: "Live",
         url:`/realtime/sections/${this.props.params.section}`,
         type: "realtime"
       },
       {
-        title: "Historical",
+        title: "Archive",
         url:`/sections/${this.props.params.section}`,
-        type: "section", timePeriod: 24
+        type: "section"
       }
     ];
 
+
     return(<DocumentTitle title={title}>
       <div>
+
+        <ChunkWrapper component="header">
+          {updating}
+
+          <Header
+            title={'Section: ' + this.props.params.section}
+          />
+        </ChunkWrapper>
 
         <TabNav
           links={links}
@@ -129,18 +138,14 @@ class SectionView extends React.Component {
           />
         </ChunkWrapper>
 
-          <ChunkWrapper component="header">
-            {updating}
-
-            <Header
-              title={'Section: ' + this.props.params.section}
-            />
-          </ChunkWrapper>
-
           <SectionHeadlineStats
             data={data}
             comparatorData={comparatorData}
             config={headlineStats}
+          />
+
+          <ArticleList
+            articleList={data.articleList}
           />
 
           <ChunkWrapper component="ArticlesPublished">

--- a/src/shared/sources/AnalyticsSource.js
+++ b/src/shared/sources/AnalyticsSource.js
@@ -25,7 +25,42 @@ let AnalyticsSource = {
     error: AnalyticsActions.loadingFailed,
     loading: AnalyticsActions.loadingData,
 
-    shouldFetch(query) {
+    shouldFetch() {
+      return true;
+    }
+
+  },
+  loadArticleList: {
+    remote(state) {
+      return DataAPI.getArticleList(state.query);
+    },
+
+    local() {
+      return null;
+    },
+
+    success: AnalyticsActions.updateArticleList,
+    error: AnalyticsActions.loadingFailed,
+    loading: AnalyticsActions.loadingData,
+
+    shouldFetch() {
+      return true;
+    }
+  },
+  loadRealtimeArticleList: {
+    remote(state) {
+      return DataAPI.getRealtimeArticleList(state.query);
+    },
+
+    local() {
+      return null;
+    },
+
+    success: AnalyticsActions.updateArticleList,
+    error: AnalyticsActions.loadingFailed,
+    loading: AnalyticsActions.loadingData,
+
+    shouldFetch() {
       return true;
     }
 

--- a/src/shared/stores/AnalyticsStore.js
+++ b/src/shared/stores/AnalyticsStore.js
@@ -78,6 +78,16 @@ class AnalyticsStore {
   }
 
   /**
+   * @param {articleList} array - an array of article data that is obtained from
+   * the query, contains the articles published
+   */
+  updateArticleList(articleList) {
+    this.setState({
+      articleList: articleList
+    });
+  }
+
+  /**
    * @param {newQueryProps} object - an object with the new query
    * properties to update
    *

--- a/src/shared/utils/DataAPIUtils.js
+++ b/src/shared/utils/DataAPIUtils.js
@@ -75,6 +75,46 @@ let DataAPI = {
       });
     },
 
+    getRealtimeArticleList(query) {
+      assert.equal(typeof query, 'object',
+        "argument 'query' must be an object");
+
+      assert.ok(query.hasOwnProperty('type'),
+        "a query type of {section, author} must be supplied")
+
+      assert.ok(query.hasOwnProperty(query.type),
+        "a specifier for the query type must be supplied")
+
+      return new Promise(function handlePromise(resolve, reject) {
+        const url = `${config.baseUrl}/api/v0/realtime/articlelist/${query.type}s/${query[query.type]}`
+        request.get(url)
+          .send(query)
+          .set('Accept', 'application/json')
+          .end(handleResponse('SectionArticleList', query, reject, resolve));
+      });
+
+    },
+
+    getArticleList(query) {
+      assert.equal(typeof query, 'object',
+        "argument 'query' must be an object");
+
+      assert.ok(query.hasOwnProperty('type'),
+        "a query type of {section, author} must be supplied")
+
+      assert.ok(query.hasOwnProperty(query.type),
+        "a specifier for the query type must be supplied")
+
+      return new Promise(function handlePromise(resolve, reject) {
+        const url = `${config.baseUrl}/api/v0/articlelist/${query.type}s/${query[query.type]}`
+        request.post(url)
+          .send(query)
+          .set('Accept', 'application/json')
+          .end(handleResponse('SectionArticleList', query, reject, resolve));
+      });
+
+    },
+
     getTopicData(query, apiKey) {
       assert.equal(typeof query, 'object',
         "argument 'query' must be an object");

--- a/src/shared/utils/convertUnits.js
+++ b/src/shared/utils/convertUnits.js
@@ -1,0 +1,42 @@
+
+function getPercentageDifference (compared , comparator) {
+  return ((Math.abs(compared-comparator)/ comparator) * 100) | 0;
+}
+
+function checkSignClass (x) {
+  return (x < 0) ? 'down' : 'up';
+}
+
+
+let convert = {
+  secondsToMinutes: (seconds) => {
+    seconds = Math.abs(seconds)
+    let metricMinutes = Math.floor(seconds / 60);
+    let metricSeconds = Math.floor(seconds - metricMinutes * 60);
+    return {minutes: metricMinutes, seconds: metricSeconds};
+  },
+  percentageDifference: (metric, comparatorMetric) => {
+    if (!comparatorMetric) return [null, null]
+    let comparatorDifference = getPercentageDifference(metric, comparatorMetric);
+    let differenceSign = checkSignClass(metric - comparatorMetric);
+    return [differenceSign, comparatorDifference + '%'];
+  },
+  time: (metric, comparatorMetric)=> {
+    let convertedMetric = convert.secondsToMinutes(metric);
+    let transformMetric = convertedMetric.minutes + 'm ' + convertedMetric.seconds + 's';
+    let [differenceSign, transformComparator] = convert.percentageDifference(metric, comparatorMetric)
+    return [transformMetric, differenceSign, transformComparator];
+  },
+  integer:  (metric, comparatorMetric)=>{
+    let transformMetric = (metric || 0).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",") // Add commas to output
+    let [differenceSign, transformComparator] = convert.percentageDifference(metric, comparatorMetric)
+    return [transformMetric, differenceSign, transformComparator];
+  },
+  percentage:  (metric, comparatorMetric)=>{
+    let transformMetric = (metric || 0) +"%";
+    let [differenceSign, transformComparator] = convert.percentageDifference(metric, comparatorMetric)
+    return [transformMetric, differenceSign, transformComparator];
+  }
+}
+
+export default convert;

--- a/test/fixtures/data/section_results.js
+++ b/test/fixtures/data/section_results.js
@@ -599,6 +599,335 @@ export default [{
           }
         ]
       },
+      "articles": {
+      "doc_count_error_upper_bound": 51126,
+      "sum_other_doc_count": 21048817,
+      "buckets": [
+        {
+          "key": "b6d1fc34-ce9f-11e5-831d-09f7778e7377",
+          "doc_count": 347203,
+          "metadata": {
+            "hits": {
+              "total": 347203,
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "article_page_view-2016-02-08",
+                  "_type": "logs",
+                  "_id": "cikei2x1900023q38w0mftvth",
+                  "_score": null,
+                  "_source": {
+                    "article_uuid": "b6d1fc34-ce9f-11e5-831d-09f7778e7377",
+                    "initial_publish_date": "2016-02-08T20:56:25.000Z",
+                    "title": "Michael Bloomberg considers joining race for the White House",
+                    "primary_section": "US Election 2016"
+                  },
+                  "sort": [
+                    "b6d1fc34-ce9f-11e5-831d-09f7778e7377"
+                  ]
+                }
+              ]
+            }
+          },
+          "avg_time_on_page": {
+            "value": 39.11566432317693
+          },
+          "retention": {
+            "doc_count": 85650
+          }
+        },
+        {
+          "key": "b57fee24-cb3c-11e5-be0b-b7ece4e953a0",
+          "doc_count": 166583,
+          "metadata": {
+            "hits": {
+              "total": 166583,
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "article_page_view-2016-02-07",
+                  "_type": "logs",
+                  "_id": "cikd19bd400037639wib4jl0q",
+                  "_score": null,
+                  "_source": {
+                    "article_uuid": "b57fee24-cb3c-11e5-be0b-b7ece4e953a0",
+                    "initial_publish_date": "2016-02-07T12:46:20.000Z",
+                    "title": "An old-school reply to an advertisers retro threat",
+                    "primary_section": "Management"
+                  },
+                  "sort": [
+                    "b57fee24-cb3c-11e5-be0b-b7ece4e953a0"
+                  ]
+                }
+              ]
+            }
+          },
+          "avg_time_on_page": {
+            "value": 51.93876926216961
+          },
+          "retention": {
+            "doc_count": 38561
+          }
+        },
+        {
+          "key": "646f7384-b623-11e5-b147-e5e5bba42e51",
+          "doc_count": 143827,
+          "metadata": {
+            "hits": {
+              "total": 143827,
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "article_page_view-2016-01-24",
+                  "_type": "logs",
+                  "_id": "t1453674014722h2r253.56436963193119",
+                  "_score": null,
+                  "_source": {
+                    "article_uuid": "646f7384-b623-11e5-b147-e5e5bba42e51",
+                    "initial_publish_date": "2016-01-24T20:05:02.000Z",
+                    "title": "Global MBA ranking 2016  analysis and school profiles"
+                  },
+                  "sort": [
+                    "646f7384-b623-11e5-b147-e5e5bba42e51"
+                  ]
+                }
+              ]
+            }
+          },
+          "avg_time_on_page": {
+            "value": 62.05159670993624
+          },
+          "retention": {
+            "doc_count": 32973
+          }
+        },
+        {
+          "key": "fcb4202a-c04d-11e5-846f-79b0e3d20eaf",
+          "doc_count": 136169,
+          "metadata": {
+            "hits": {
+              "total": 136169,
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "article_page_view-2016-01-25",
+                  "_type": "logs",
+                  "_id": "t1453719086359h12r729.0424692910165",
+                  "_score": null,
+                  "_source": {
+                    "article_uuid": "fcb4202a-c04d-11e5-846f-79b0e3d20eaf",
+                    "initial_publish_date": "2016-01-25T09:06:01.000Z",
+                    "title": "Talk of Fed policy error grows"
+                  },
+                  "sort": [
+                    "fcb4202a-c04d-11e5-846f-79b0e3d20eaf"
+                  ]
+                }
+              ]
+            }
+          },
+          "avg_time_on_page": {
+            "value": 41.317568609595426
+          },
+          "retention": {
+            "doc_count": 33662
+          }
+        },
+        {
+          "key": "8acceda4-ba0b-11e5-bf7e-8a339b6f2164",
+          "doc_count": 128071,
+          "metadata": {
+            "hits": {
+              "total": 128071,
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "article_page_view-2016-01-17",
+                  "_type": "logs",
+                  "_id": "cijiyras600032z3864z5bj60",
+                  "_score": null,
+                  "_source": {
+                    "article_uuid": "8acceda4-ba0b-11e5-bf7e-8a339b6f2164",
+                    "initial_publish_date": "2016-01-17T13:11:23.000Z",
+                    "title": "Deloitte chiefs new year memo is a classic in demotivation"
+                  },
+                  "sort": [
+                    "8acceda4-ba0b-11e5-bf7e-8a339b6f2164"
+                  ]
+                }
+              ]
+            }
+          },
+          "avg_time_on_page": {
+            "value": 43.18778646219675
+          },
+          "retention": {
+            "doc_count": 48635
+          }
+        },
+        {
+          "key": "59c763a8-c24c-11e5-b3b1-7b2481276e45",
+          "doc_count": 123920,
+          "metadata": {
+            "hits": {
+              "total": 123920,
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "article_page_view-2016-01-24",
+                  "_type": "logs",
+                  "_id": "t1453661728248h3r237.81065503135324",
+                  "_score": null,
+                  "_source": {
+                    "article_uuid": "59c763a8-c24c-11e5-b3b1-7b2481276e45",
+                    "initial_publish_date": "2016-01-24T13:57:52.000Z",
+                    "title": "Apple results: talk swirls of iPhone decline"
+                  },
+                  "sort": [
+                    "59c763a8-c24c-11e5-b3b1-7b2481276e45"
+                  ]
+                }
+              ]
+            }
+          },
+          "avg_time_on_page": {
+            "value": 59.04701420271142
+          },
+          "retention": {
+            "doc_count": 46686
+          }
+        },
+        {
+          "key": "cdcc295c-c290-11e5-b3b1-7b2481276e45",
+          "doc_count": 96433,
+          "metadata": {
+            "hits": {
+              "total": 96433,
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "article_page_view-2016-01-24",
+                  "_type": "logs",
+                  "_id": "t1453676598688h3r373.4026844613254",
+                  "_score": null,
+                  "_source": {
+                    "article_uuid": "cdcc295c-c290-11e5-b3b1-7b2481276e45",
+                    "initial_publish_date": "2016-01-24T12:25:31.000Z",
+                    "title": "Iran plans to buy 114 Airbus jets on Rouhanis Europe visit"
+                  },
+                  "sort": [
+                    "cdcc295c-c290-11e5-b3b1-7b2481276e45"
+                  ]
+                }
+              ]
+            }
+          },
+          "avg_time_on_page": {
+            "value": 48.08618419005942
+          },
+          "retention": {
+            "doc_count": 34035
+          }
+        },
+        {
+          "key": "ef24be04-be8d-11e5-9fdb-87b8d15baec2",
+          "doc_count": 95908,
+          "metadata": {
+            "hits": {
+              "total": 95908,
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "article_page_view-2016-01-20",
+                  "_type": "logs",
+                  "_id": "t1453276368312h12r219.8961975518614",
+                  "_score": null,
+                  "_source": {
+                    "article_uuid": "ef24be04-be8d-11e5-9fdb-87b8d15baec2",
+                    "initial_publish_date": "2016-01-19T14:51:17.000Z",
+                    "title": "Davos 2016: The 4 big themes facing the World Economic Forum"
+                  },
+                  "sort": [
+                    "ef24be04-be8d-11e5-9fdb-87b8d15baec2"
+                  ]
+                }
+              ]
+            }
+          },
+          "avg_time_on_page": {
+            "value": 51.28589898652876
+          },
+          "retention": {
+            "doc_count": 29049
+          }
+        },
+        {
+          "key": "b33d75fe-cc5a-11e5-be0b-b7ece4e953a0",
+          "doc_count": 86541,
+          "metadata": {
+            "hits": {
+              "total": 86541,
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "article_page_view-2016-02-07",
+                  "_type": "logs",
+                  "_id": "t1454874682421h2r444.625711068511",
+                  "_score": null,
+                  "_source": {
+                    "article_uuid": "b33d75fe-cc5a-11e5-be0b-b7ece4e953a0",
+                    "initial_publish_date": "2016-02-07T18:43:14.000Z",
+                    "title": "Google pushes further into virtual reality with new headset",
+                    "primary_section": "Technology"
+                  },
+                  "sort": [
+                    "b33d75fe-cc5a-11e5-be0b-b7ece4e953a0"
+                  ]
+                }
+              ]
+            }
+          },
+          "avg_time_on_page": {
+            "value": 37.696918223732105
+          },
+          "retention": {
+            "doc_count": 34401
+          }
+        },
+        {
+          "key": "4ea4deb4-baaf-11e5-bf7e-8a339b6f2164",
+          "doc_count": 81685,
+          "metadata": {
+            "hits": {
+              "total": 81685,
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "article_page_view-2016-01-24",
+                  "_type": "logs",
+                  "_id": "cijt0v2so00037038b45zlan6",
+                  "_score": null,
+                  "_source": {
+                    "article_uuid": "4ea4deb4-baaf-11e5-bf7e-8a339b6f2164",
+                    "initial_publish_date": "2016-01-24T17:02:17.000Z",
+                    "title": "Inseads 1-year MBA tops FT rankings"
+                  },
+                  "sort": [
+                    "4ea4deb4-baaf-11e5-bf7e-8a339b6f2164"
+                  ]
+                }
+              ]
+            }
+          },
+          "avg_time_on_page": {
+            "value": 43.887066168819246
+          },
+          "retention": {
+            "doc_count": 30220
+          }
+        }
+      ]
+    },
       "referrer": {
         "doc_count": 447093,
         "types": {

--- a/test/formatters/Sections.spec.js
+++ b/test/formatters/Sections.spec.js
@@ -62,7 +62,8 @@ describe('Section Formatter', function() {
           'uniqueVisitors',
           'topicCount',
           'topicViews',
-          'articleCount'
+          'articleCount',
+          'articleList'
         ];
         for (let i = 0; i < props.length; i++){
           try{


### PR DESCRIPTION
There are now two new endpoints for article lists, namely:

`GET /realtime/articlelist/section/:section`
`POST /articlelist/section/:section`

which use *single queries* (thanks Lucas!) to get all the articles on both realtime and historical views.

We have also added the article list to the Archive section view:
<img width="967" alt="screen shot 2016-02-15 at 16 48 10" src="https://cloud.githubusercontent.com/assets/780409/13054902/06161942-d404-11e5-8378-67b57cedd3d8.png">

also fixed a bug with comparators where selecting FT would display data for FT rather than for the current section