### PR TITLE
Pick of the Day bugfix for element `data-component` in Top 5 from Search Engines

### DIFF
--- a/src/shared/handlers/TopArticlesView.js
+++ b/src/shared/handlers/TopArticlesView.js
@@ -260,7 +260,7 @@ class TopArticlesView extends React.Component {
           </Row>
         </ChunkWrapper>
 
-        <ChunkWrapper component="Top5FromSocialMedia">
+        <ChunkWrapper component="Top5FromSearchEngines">
           <Row>
             <Col xs={12}>
               <h3>Top 5 - Traffic from search engines</h3>


### PR DESCRIPTION
Reflecting this Trello bug:
https://trello.com/c/RV4jEL2W/583-bug-pick-of-the-day-element-top-5-traffic-from-search-engines-has-data-component-top5fromsocialmedia

Top 5 traffic from search engines no longer has data-component `Top5FromSocialMedia`