### PR TITLE
Remove the topics tagged/view tables from sections

### DIFF
--- a/src/shared/components/ChunkWrapper.js
+++ b/src/shared/components/ChunkWrapper.js
@@ -11,8 +11,13 @@ export default class ChunkWrapper extends React.Component {
       borderBottom: '1px solid #ccc'
     };
 
+
     if (this.props.noBorder) {
       delete style.borderBottom;
+    }
+
+    if (!this.props.featureflag) {
+      return null; 
     }
 
     return (
@@ -25,3 +30,7 @@ export default class ChunkWrapper extends React.Component {
   }
 
 }
+
+ChunkWrapper.defaultProps = {
+  featureflag : true
+};

--- a/src/shared/config/default.js
+++ b/src/shared/config/default.js
@@ -33,6 +33,7 @@ let config = {
     'article:modifier:DateRange' : true,
     'section:who' : true,
     'section:where' : true,
+    'section:topics' : false,
     'topic:who' : true,
     'topic:where' : true
   }

--- a/src/shared/handlers/SectionView.js
+++ b/src/shared/handlers/SectionView.js
@@ -172,7 +172,7 @@ class SectionView extends React.Component {
             </Row>
           </ChunkWrapper>
 
-          <ChunkWrapper component="Topics">
+          <ChunkWrapper featureflag={FeatureFlag.check('section:topics')} component="Topics">
             <Row>
               <Col xs={12}>
                 <h3>Topics Published vs Topics Read</h3>


### PR DESCRIPTION
Remove the topics tagged/view tables from sections - commented out so that they can be later returned when data is ready

https://trello.com/c/sYcTNBg9