### PR TITLE
unfilter social referrers on article query

### DIFF
--- a/src/server/aggregations/Articles.js
+++ b/src/server/aggregations/Articles.js
@@ -75,11 +75,6 @@ export default function ArticlesAggregation(query) {
                       }
                     },
                     {
-                      term: {
-                        referrer_type: "social-network"
-                      }
-                    },
-                    {
                       prefix: {
                         referrer: "http://localhost"
                       }


### PR DESCRIPTION
We had disabled social referrers from showing up on external referrers, but a bug has been filed to reinstate them. This reinstates them