### PR TITLE
Sets primary section of article as default comparator for articles

### DIFF
--- a/src/server/esClient.js
+++ b/src/server/esClient.js
@@ -140,6 +140,7 @@ export function runArticleQuery(queryData) {
   let metaData;
   return retrieveMetaData(queryData).then((data) => {
     metaData = data;
+
     queryData.publishDate = moment(metaData.initial_publish_date).toISOString();
     if (queryData.timespan && queryData.timespan !== 'custom') {
       queryData.dateFrom = queryData.publishDate;
@@ -149,6 +150,12 @@ export function runArticleQuery(queryData) {
       queryData.dateFrom = queryData.publishDate
       queryData.dateTo = moment().toISOString();
     }
+
+    if (!queryData.comparator) {
+      queryData.comparatorType = 'section';
+      queryData.comparator = metaData.primary_section.split(',')[0];
+    }
+
     return retrieveArticleData(queryData)
   }).then((articleData) => {
     return [metaData].concat(articleData);

--- a/src/server/formatters/Articles.js
+++ b/src/server/formatters/Articles.js
@@ -35,7 +35,7 @@ export default function formatData(data) {
   }
 
   let [metaData, articleData, eventData, articleComparatorData, eventComparatorData, articlePublishTimesData] = data;
-  let metaFields = ['title', 'uuid', 'author', 'published', 'published_human', 'genre', 'sections', 'topics']
+  let metaFields = ['title', 'uuid', 'author', 'published', 'published_human', 'genre', 'sections', 'topics', 'primarySection']
   let articleFields = [
     'pageViews', 'timeOnPage', 'readTimes', 'channels', 'uniqueVisitors',
     'isSubscription', 'nextInternalUrl', 'internalReferrerTypes', 'internalReferrerUrls', 'isFirstVisit',

--- a/src/server/routers/dataPreloader-routes.js
+++ b/src/server/routers/dataPreloader-routes.js
@@ -30,6 +30,15 @@ router.get(`/realtime/articles/:uuid(${UUID_REGEX})/:timespan`, (req, res, next)
     });
 });
 
+router.get(`/articles/:uuid(${UUID_REGEX})/:timespan`, (req, res, next) => {
+  return getArticleData(req, res)
+    .then(() => next())
+    .catch((err) => {
+      if (err.status) res.status(err.status);
+      next(err);
+    });
+});
+
 router.get(`/articles/:uuid(${UUID_REGEX})/:timespan/:comparatorType(${COMPTYPE_REGEX})/:comparator`, (req, res, next) => {
   return getArticleData(req, res)
     .then(() => next())

--- a/src/server/utils/universalDataFormatter.js
+++ b/src/server/utils/universalDataFormatter.js
@@ -29,6 +29,7 @@ const fields = {
   author : 'authors',
   genre : 'genre',
   sections : 'sections',
+  primarySection : 'primary_section',
   topics : 'topics',
   published: 'initial_publish_date',
   published_human: {name:'initial_publish_date', formatter: formatPublishDate},

--- a/src/shared/components/QueryLink.js
+++ b/src/shared/components/QueryLink.js
@@ -19,7 +19,12 @@ export default class QueryLink extends React.Component {
         }
         break;
       case 'article' :
-        url = `/${query.type}s/${query.uuid}/${query.timespan}/${query.comparatorType}/${query.comparator}`
+        if (query.comparatorType) {
+          url = `/${query.type}s/${query.uuid}/${query.timespan}/${query.comparatorType}/${query.comparator}`;
+        }
+        else {
+          url = `/${query.type}s/${query.uuid}/${query.timespan}`;
+        }
         break;
       case 'realtimeArticle' :
         url = `/realtime/articles/${query.uuid}/${query.timespan}`

--- a/src/shared/components/SectionModifier.js
+++ b/src/shared/components/SectionModifier.js
@@ -76,11 +76,24 @@ export default class Modifier extends React.Component {
     let arrAuthors = data.author;
     if (!Array.isArray(arrAuthors)) arrAuthors = [arrAuthors]
     if (!arrAuthors[0]) arrAuthors=[]
+
+    let primarySections = data.primarySection.split(',');
+    let firstPrimarySection = primarySections[0];
+    let comparator = this.props.comparatorQuery.comparator || firstPrimarySection;
+
+    function listAllSections (sections, primarySections) {
+      return sections.concat(primarySections.filter(function(primarySection) {
+        return sections.indexOf(primarySection) == -1;
+      }))
+    }
+
+    let allSections = listAllSections(data.sections, primarySections);
+
     let tags = [{label:'FT',url:`global/FT`}]
       .concat(
       data.topics.map(d => {return {label:d, url:`topic/${d}`}})
     ).concat(
-      data.sections.map(d => {return {label:d, url:`section/${d}`}})
+      allSections.map(d => {return {label:d, url:`section/${d}`}})
     ).concat(
       data.genre.map(d => {return {label:d, url:`genre/${d}`}})
     ).concat(
@@ -165,7 +178,7 @@ export default class Modifier extends React.Component {
           >
             <Tags
               tags={tags}
-              currentTag={this.props.comparatorQuery.comparator}
+              currentTag={comparator}
               uuid={this.props.uuid}
               category={this.props.category}
               comparatorQuery={this.props.comparatorQuery}

--- a/src/shared/handlers/HistoricalAnalyticsView.js
+++ b/src/shared/handlers/HistoricalAnalyticsView.js
@@ -136,7 +136,8 @@ class HistoricalAnalyticsView extends React.Component {
 
     switch (this.props.route.analyticsView) {
       case VIEW_TYPE_ARTICLE:
-        this.props.history.push(`/articles/${params.uuid}/custom/${params.comparatorType}/${params.comparator}?dateFrom=${dateFrom}&dateTo=${dateTo}`);
+        comparatorPath = (params.comparator) ? `/${params.comparatorType}/${params.comparator}` : '';
+        this.props.history.push(`/articles/${params.uuid}/custom${comparatorPath}?dateFrom=${dateFrom}&dateTo=${dateTo}`);
         break;
       case VIEW_TYPE_SECTION:
         comparatorPath = (params.comparator) ? `/${params.comparatorType}/${params.comparator}` : '';

--- a/src/shared/routers/routes.js
+++ b/src/shared/routers/routes.js
@@ -35,9 +35,6 @@ export default (
         component={PlaygroundLoader}
       />
     </Route>
-    <Redirect from="articles/:uuid(/:timespan)"
-      to="articles/:uuid/48/global/FT"
-    />
     <Route
       path="articles/:uuid"
       component={HistoricalAnalyticsView}
@@ -45,12 +42,11 @@ export default (
       analyticsView="article"
     >
       <Route
-        path=":timespan/:comparatorType/:comparator"
+        path=":timespan(/:comparatorType/:comparator)"
         component={HistoricalAnalyticsView}
         onEnter={scrollToTop}
         analyticsView="article"
-        >
-      </Route>
+        />
     </Route>
     <Redirect from="sections/:section"
       to="sections/:section/168"

--- a/src/shared/stores/AnalyticsStore.js
+++ b/src/shared/stores/AnalyticsStore.js
@@ -21,8 +21,8 @@ function newState() {
       dateFrom: null,
       dateTo: null,
       filters: {},
-      comparator: 'FT',
-      comparatorType: 'global',
+      comparator: null,
+      comparatorType: null,
       publishDate: null
     },
     availableFilters: {

--- a/test/components/sectionModifier.spec.js
+++ b/test/components/sectionModifier.spec.js
@@ -13,7 +13,7 @@ describe ('Modifier component', function() {
 
   beforeEach(function() {
     modifier = createComponent(SectionModifier, {
-      data:{ topics: [], sections:[], genre:[], author:[]},
+      data:{ topics: [], sections:[], genre:[], author:[], primarySection:''},
       comparatorData:{},
       renderDateRange: true,
       renderComparator: true,


### PR DESCRIPTION
Adds primary section to the query
Put primary section into tags if it is not there already. Choose first primary section if there are multiple for default comparison

Update unit test for section modifier

Updates timespan mechanics to allow for no comparator in url. Updates routing