### PR TITLE
Limit comparator search to articles published up to 30 days before the article compared was published

### DIFF
--- a/src/server/esQueries/ArticleComparator.js
+++ b/src/server/esQueries/ArticleComparator.js
@@ -7,13 +7,7 @@ export default function ArticleComparatorESQuery(query) {
     "argument 'query' should be an object");
 
   let comparatorQuery = ArticleComparatorQuery(query)
-  let must = comparatorQuery.filtered.query.bool.must;
 
-  if (must.length <= 1) {
-    delete comparatorQuery.filtered.query.bool.must;
-  } else {
-    comparatorQuery.filtered.query.bool.must.splice(0,1);
-  }
 
   let esQuery = {
     "query" : comparatorQuery,

--- a/src/server/esQueries/ArticleEventsComparator.js
+++ b/src/server/esQueries/ArticleEventsComparator.js
@@ -9,13 +9,6 @@ export default function ArticleEventsComparatorESQuery(query) {
 
   let comparatorQuery = ArticleComparatorQuery(query)
 
-  // we don't need the date range here
-  let must = comparatorQuery.filtered.query.bool.must;
-  if (must.length > 1) {
-    must.splice(0,1);
-  } else {
-    delete comparatorQuery.filtered.query.bool.must;
-  }
   return {
     "query" : comparatorQuery,
     "size": 0,


### PR DESCRIPTION
We were querying *all* articles, but now we only query events for articles whose `initial_publish_date` is 30 days before the `initial_publish_date` of the article being queried.

this fixes [this trello card](https://trello.com/c/PBQKgZl0/590-bug-article-comparator-calculations-are-incorrect-missing-initial-publish-time-restriction)