### PR TITLE
Correct visitor count on article comparators

### DIFF
--- a/src/server/aggregations/ArticleComparator.js
+++ b/src/server/aggregations/ArticleComparator.js
@@ -1,6 +1,4 @@
-import * as calculateInterval from '../utils/calculateInterval'
-
-export default function ArticleComparatorAggregation(query) {
+export default function ArticleComparatorAggregation() {
   return {
       avg_time_on_page : {
         avg : {
@@ -151,8 +149,16 @@ export default function ArticleComparatorAggregation(query) {
         }
       },
       unique_visitors: {
-        cardinality: {
-          field: 'visitor_id'
+        terms: {
+          field: 'article_uuid',
+          size: 10000000
+        },
+        aggs: {
+          unique_visitors: {
+            cardinality: {
+              field: 'visitor_id'
+            }
+          }
         }
       }
   }

--- a/src/server/aggregations/SectionMetadata.js
+++ b/src/server/aggregations/SectionMetadata.js
@@ -11,13 +11,18 @@ export default function SectionMetadataAggregation(query) {
       },
       topics_covered: {
         cardinality: {
-          field: "topics"
+          field: "topics_not_analyzed"
         }
       },
       topic_count: {
         terms: {
           field: "topics_not_analyzed",
           size : 10
+        }
+      },
+      distinct_articles: {
+        cardinality: {
+          field: "article_uuid"
         }
       }
     }

--- a/src/server/aggregations/SectionMetadataComparator.js
+++ b/src/server/aggregations/SectionMetadataComparator.js
@@ -1,15 +1,20 @@
 export default function SectionMetadataComparatorAggregation() {
   return {
-      "topics_covered": {
-        "cardinality": {
-          "field": "topics"
-        }
-      },
-      "topic_count": {
-        "terms": {
-          "field": "topics_not_analyzed",
-          size : 10
-        }
+    topics_covered: {
+      cardinality: {
+        field: "topics_not_analyzed"
       }
+    },
+    topic_count: {
+      terms: {
+        field: "topics_not_analyzed",
+        size : 10
+      }
+    },
+    distinct_articles: {
+      cardinality: {
+        field: "article_uuid"
+      }
+    }
   }
 }

--- a/src/server/aggregations/Sections.js
+++ b/src/server/aggregations/Sections.js
@@ -116,11 +116,6 @@ export default function SectionAggregation(query) {
         "field": "topics_not_analyzed",
         size: 10
       }
-    },
-    distinct_articles: {
-      cardinality: {
-        field: "article_uuid"
-      }
     }
   }
 }

--- a/src/server/esQueries/ArticleList.js
+++ b/src/server/esQueries/ArticleList.js
@@ -22,6 +22,11 @@ export default function ArticleListQuery(query) {
                 to: query.dateTo
               }
             }
+          },
+          {
+            match: {
+              page_type: 'article'
+            }
           }
         ]
       }

--- a/src/server/esQueries/ArticleRealTime.js
+++ b/src/server/esQueries/ArticleRealTime.js
@@ -16,8 +16,19 @@ export default function ArticlesRealtimeESQuery(query) {
 
   return {
     query: {
-      match: {
-        article_uuid : query.uuid
+      bool: {
+        must: [
+          {
+            match: {
+              article_uuid : query.uuid
+            }
+          },
+          {
+            match: {
+              page_type: 'article'
+            }
+          }
+        ]
       }
     },
     size: 1,

--- a/src/server/esQueries/SectionRealTime.js
+++ b/src/server/esQueries/SectionRealTime.js
@@ -34,6 +34,11 @@ export default function SectionRealtimeESQuery(query) {
             match: {
               primary_section : query.section
             }
+          },
+          {
+            match: {
+              page_type: 'article'
+            }
           }
         ]
       }

--- a/src/server/formatters/Sections.js
+++ b/src/server/formatters/Sections.js
@@ -24,9 +24,9 @@ export default function SectionDataFormatter(data) {
     let [metaData, sectionData, compMetaData, compData] = data;
     try {
       let results = {genre:[],sections:[], topics:[]}
-      let metaFields = ['topicsCovered', 'topicCount', 'publishTimes']
+      let metaFields = ['articleCount', 'topicsCovered', 'topicCount', 'publishTimes']
       let sectionFields = [
-        'articleCount', 'readTimes', 'pageViews', 'referrerTypes',
+        'readTimes', 'pageViews', 'referrerTypes',
         'referrerNames', 'socialReferrers', 'devices', 'countries',
         'regions', 'userCohort', 'rfvCluster', 'isFirstVisit',
         'internalReferrerTypes', 'isSubscription', 'uniqueVisitors',
@@ -39,8 +39,8 @@ export default function SectionDataFormatter(data) {
 
       let comparatorResults = {};
       if (compMetaData) {
-        let compMetaFields = ['topicsCovered', 'topicCount']
-        let compSectionFields = ['comparator', 'articleCount', 'pageViews', 'referrerTypes',
+        let compMetaFields = ['articleCount', 'topicsCovered', 'topicCount']
+        let compSectionFields = ['comparator', 'pageViews', 'referrerTypes',
           'referrerNames', 'socialReferrers', 'devices', 'countries', 'regions', 'userCohort',
           'rfvCluster', 'isFirstVisit', 'internalReferrerTypes', 'isSubscription', 'uniqueVisitors',
           'topicViews'

--- a/src/server/utils/universalDataFormatter.js
+++ b/src/server/utils/universalDataFormatter.js
@@ -79,7 +79,7 @@ const fields = {
   articleCount: 'aggregations.distinct_articles.value',
   categoryTotalViewCount: 'aggregations.page_view_total_count.value',
   categoryAverageViewCount: {name: 'aggregations.page_view_total_count.value', formatter: divide},
-  categoryAverageUniqueVisitors: {name: 'aggregations.unique_visitors.value', formatter: divide},
+  categoryAverageUniqueVisitors: {name: 'aggregations.unique_visitors', formatter: average, bucket_key: 'unique_visitors'},
   readTimes: {name: 'aggregations.page_views_over_time', formatter: format},
   headlineStatsOverTime : 'aggregations.headline_stats_over_time.buckets',
   scrollOverTime : 'aggregations.scroll_over_time.buckets',
@@ -124,6 +124,13 @@ const fields = {
   lastPublishDate: 'aggregations.last_publish_date.buckets',
   realtimeTopicsCovered: 'aggregations.topics_covered.value',
   realtimeArticlesPublished: 'aggregations.articles_published.value'
+}
+
+function average(agg, fieldObj) {
+  const sum = agg.buckets.reduce((prev, curr) => {
+    return prev + curr[fieldObj.bucket_key].value;
+  }, 0);
+  return sum / agg.buckets.length;
 }
 
 function divide(agg, fieldObj, divisor=1){

--- a/test/fixtures/data/article_comparator_results.js
+++ b/test/fixtures/data/article_comparator_results.js
@@ -488,7 +488,174 @@ export default [{
           "doc_count": 5
         }
       ]
-    }
+    },
+    "unique_visitors": {
+      "doc_count_error_upper_bound": 0,
+      "sum_other_doc_count": 0,
+      "buckets": [
+        {
+          "key": "03ae3552-d186-11e5-831d-09f7778e7377",
+          "doc_count": 15034,
+          "unique_visitors": {
+            "value": 12360
+          }
+        },
+        {
+          "key": "c95abbc2-cbe1-11e5-be0b-b7ece4e953a0",
+          "doc_count": 9642,
+          "unique_visitors": {
+            "value": 7778
+          }
+        },
+        {
+          "key": "70e6ee72-d3fa-11e5-969e-9d801cf5e15b",
+          "doc_count": 8695,
+          "unique_visitors": {
+            "value": 7076
+          }
+        },
+        {
+          "key": "24c61c06-d4a5-11e5-829b-8564e7528e54",
+          "doc_count": 8016,
+          "unique_visitors": {
+            "value": 6375
+          }
+        },
+        {
+          "key": "a3267dfe-cc1a-11e5-be0b-b7ece4e953a0",
+          "doc_count": 6272,
+          "unique_visitors": {
+            "value": 4763
+          }
+        },
+        {
+          "key": "878fa516-ce63-11e5-831d-09f7778e7377",
+          "doc_count": 5793,
+          "unique_visitors": {
+            "value": 4507
+          }
+        },
+        {
+          "key": "351b86c8-cf18-11e5-831d-09f7778e7377",
+          "doc_count": 3387,
+          "unique_visitors": {
+            "value": 2852
+          }
+        },
+        {
+          "key": "7405277a-cc2c-11e5-a8ef-ea66e967dd44",
+          "doc_count": 2664,
+          "unique_visitors": {
+            "value": 2147
+          }
+        },
+        {
+          "key": "9bdbfbd4-cfe7-11e5-92a1-c5e23ef99c77",
+          "doc_count": 2482,
+          "unique_visitors": {
+            "value": 1755
+          }
+        },
+        {
+          "key": "0b462a2a-cbe3-11e5-be0b-b7ece4e953a0",
+          "doc_count": 2417,
+          "unique_visitors": {
+            "value": 1873
+          }
+        },
+        {
+          "key": "b093839a-cb5e-11e5-a8ef-ea66e967dd44",
+          "doc_count": 2225,
+          "unique_visitors": {
+            "value": 1765
+          }
+        },
+        {
+          "key": "65231676-d583-11e5-8887-98e7feb46f27",
+          "doc_count": 1813,
+          "unique_visitors": {
+            "value": 1425
+          }
+        },
+        {
+          "key": "8aaea406-cff1-11e5-831d-09f7778e7377",
+          "doc_count": 1756,
+          "unique_visitors": {
+            "value": 1385
+          }
+        },
+        {
+          "key": "0ace3536-cb36-11e5-a8ef-ea66e967dd44",
+          "doc_count": 1522,
+          "unique_visitors": {
+            "value": 1322
+          }
+        },
+        {
+          "key": "bbbc342a-d099-11e5-92a1-c5e23ef99c77",
+          "doc_count": 1171,
+          "unique_visitors": {
+            "value": 1015
+          }
+        },
+        {
+          "key": "d379403e-ca5f-11e5-a8ef-ea66e967dd44",
+          "doc_count": 990,
+          "unique_visitors": {
+            "value": 853
+          }
+        },
+        {
+          "key": "60c954c6-d558-11e5-829b-8564e7528e54",
+          "doc_count": 445,
+          "unique_visitors": {
+            "value": 392
+          }
+        },
+        {
+          "key": "80b15db4-ca87-11e5-be0b-b7ece4e953a0",
+          "doc_count": 360,
+          "unique_visitors": {
+            "value": 315
+          }
+        },
+        {
+          "key": "06f1bafa-ca64-11e5-a8ef-ea66e967dd44",
+          "doc_count": 233,
+          "unique_visitors": {
+            "value": 202
+          }
+        },
+        {
+          "key": "9f9aba4e-c9d4-11e5-a8ef-ea66e967dd44",
+          "doc_count": 66,
+          "unique_visitors": {
+            "value": 56
+          }
+        },
+        {
+          "key": "2c8d577c-c98f-11e5-be0b-b7ece4e953a0",
+          "doc_count": 57,
+          "unique_visitors": {
+            "value": 46
+          }
+        },
+        {
+          "key": "5affd234-c975-11e5-84df-70594b99fc47",
+          "doc_count": 35,
+          "unique_visitors": {
+            "value": 31
+          }
+        },
+        {
+          "key": "922dcc26-c357-11e5-808f-8231cd71622e",
+          "doc_count": 1,
+          "unique_visitors": {
+            "value": 1
+          }
+        }
+      ]
+    },
   },
   comparator: 'Regulation & Governance'
 }, {

--- a/test/fixtures/data/article_results.js
+++ b/test/fixtures/data/article_results.js
@@ -1507,7 +1507,171 @@ export default [{
       }]
     },
     "unique_visitors": {
-      "value": 1277458
+      "doc_count_error_upper_bound": 0,
+      "sum_other_doc_count": 0,
+      "buckets": [
+        {
+          "key": "03ae3552-d186-11e5-831d-09f7778e7377",
+          "doc_count": 15034,
+          "unique_visitors": {
+            "value": 12360
+          }
+        },
+        {
+          "key": "c95abbc2-cbe1-11e5-be0b-b7ece4e953a0",
+          "doc_count": 9642,
+          "unique_visitors": {
+            "value": 7778
+          }
+        },
+        {
+          "key": "70e6ee72-d3fa-11e5-969e-9d801cf5e15b",
+          "doc_count": 8695,
+          "unique_visitors": {
+            "value": 7076
+          }
+        },
+        {
+          "key": "24c61c06-d4a5-11e5-829b-8564e7528e54",
+          "doc_count": 8016,
+          "unique_visitors": {
+            "value": 6375
+          }
+        },
+        {
+          "key": "a3267dfe-cc1a-11e5-be0b-b7ece4e953a0",
+          "doc_count": 6272,
+          "unique_visitors": {
+            "value": 4763
+          }
+        },
+        {
+          "key": "878fa516-ce63-11e5-831d-09f7778e7377",
+          "doc_count": 5793,
+          "unique_visitors": {
+            "value": 4507
+          }
+        },
+        {
+          "key": "351b86c8-cf18-11e5-831d-09f7778e7377",
+          "doc_count": 3387,
+          "unique_visitors": {
+            "value": 2852
+          }
+        },
+        {
+          "key": "7405277a-cc2c-11e5-a8ef-ea66e967dd44",
+          "doc_count": 2664,
+          "unique_visitors": {
+            "value": 2147
+          }
+        },
+        {
+          "key": "9bdbfbd4-cfe7-11e5-92a1-c5e23ef99c77",
+          "doc_count": 2482,
+          "unique_visitors": {
+            "value": 1755
+          }
+        },
+        {
+          "key": "0b462a2a-cbe3-11e5-be0b-b7ece4e953a0",
+          "doc_count": 2417,
+          "unique_visitors": {
+            "value": 1873
+          }
+        },
+        {
+          "key": "b093839a-cb5e-11e5-a8ef-ea66e967dd44",
+          "doc_count": 2225,
+          "unique_visitors": {
+            "value": 1765
+          }
+        },
+        {
+          "key": "65231676-d583-11e5-8887-98e7feb46f27",
+          "doc_count": 1813,
+          "unique_visitors": {
+            "value": 1425
+          }
+        },
+        {
+          "key": "8aaea406-cff1-11e5-831d-09f7778e7377",
+          "doc_count": 1756,
+          "unique_visitors": {
+            "value": 1385
+          }
+        },
+        {
+          "key": "0ace3536-cb36-11e5-a8ef-ea66e967dd44",
+          "doc_count": 1522,
+          "unique_visitors": {
+            "value": 1322
+          }
+        },
+        {
+          "key": "bbbc342a-d099-11e5-92a1-c5e23ef99c77",
+          "doc_count": 1171,
+          "unique_visitors": {
+            "value": 1015
+          }
+        },
+        {
+          "key": "d379403e-ca5f-11e5-a8ef-ea66e967dd44",
+          "doc_count": 990,
+          "unique_visitors": {
+            "value": 853
+          }
+        },
+        {
+          "key": "60c954c6-d558-11e5-829b-8564e7528e54",
+          "doc_count": 445,
+          "unique_visitors": {
+            "value": 392
+          }
+        },
+        {
+          "key": "80b15db4-ca87-11e5-be0b-b7ece4e953a0",
+          "doc_count": 360,
+          "unique_visitors": {
+            "value": 315
+          }
+        },
+        {
+          "key": "06f1bafa-ca64-11e5-a8ef-ea66e967dd44",
+          "doc_count": 233,
+          "unique_visitors": {
+            "value": 202
+          }
+        },
+        {
+          "key": "9f9aba4e-c9d4-11e5-a8ef-ea66e967dd44",
+          "doc_count": 66,
+          "unique_visitors": {
+            "value": 56
+          }
+        },
+        {
+          "key": "2c8d577c-c98f-11e5-be0b-b7ece4e953a0",
+          "doc_count": 57,
+          "unique_visitors": {
+            "value": 46
+          }
+        },
+        {
+          "key": "5affd234-c975-11e5-84df-70594b99fc47",
+          "doc_count": 35,
+          "unique_visitors": {
+            "value": 31
+          }
+        },
+        {
+          "key": "922dcc26-c357-11e5-808f-8231cd71622e",
+          "doc_count": 1,
+          "unique_visitors": {
+            "value": 1
+          }
+        }
+      ]
     },
     "internal_referrer": {
       "doc_count": 1951148,

--- a/test/fixtures/realtimeQuery.js
+++ b/test/fixtures/realtimeQuery.js
@@ -1,7 +1,18 @@
 export default {
   query: {
-    match: {
-      article_uuid: "f02cca28-9028-11e5-bd82-c1fb87bef7af"
+    bool: {
+      must : [
+        {
+          match: {
+            article_uuid: "f02cca28-9028-11e5-bd82-c1fb87bef7af"
+          }
+        },
+        {
+          match: {
+            page_type: 'article'
+          }
+        }
+      ]
     }
   },
   size: 1,


### PR DESCRIPTION
- [x] Fix article comparator unique visitor count to use an average computed over a terms query
- [x] Use `topics_not_analyzed` to compute topic counts on section pages
- [x] Get the number of articles published for a section from `article_metadata` rather than pageviews
- [x] Ensure realtime queries match on `page_type: 'article'` 