### PR TITLE
Update the x axis to display in 'k' rather than 1000s

### DIFF
--- a/src/shared/components/BarChart.js
+++ b/src/shared/components/BarChart.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import isBrowser from '../utils/isBrowser';
-import responsiveStyles from '../utils/responsiveStyles';
 import chartHelpers from '../utils/chartHelpers';
 import _ from 'underscore';
 import md5 from 'md5';
@@ -74,6 +73,17 @@ export default class BarChart extends React.Component {
       }
     }
 
+    const yAxisFormatter = (val) => {
+      if(val > 1) {
+        const prefix = d3.formatPrefix(val);
+        const symbol = prefix.symbol;
+        const scaledVal = prefix.scale(val);
+        return `${scaledVal}${symbol}`;
+      } else {
+        return val
+      }
+    }
+
     this.chart = c3.generate({
       bindto: node,
       transition: {
@@ -107,6 +117,9 @@ export default class BarChart extends React.Component {
           padding: {
             top: 0,
             bottom: 0
+          },
+          tick: {
+            format: yAxisFormatter
           }
         }
       },
@@ -180,7 +193,5 @@ BarChart.defaultProps = {
 
 BarChart.propTypes = {
   category: React.PropTypes.string.isRequired,
-  //data: React.PropTypes.array.isRequired,
-  //keys: React.PropTypes.array.isRequired,
   yLabel: React.PropTypes.string.isRequired
 };

--- a/src/shared/handlers/ArticleRealtimeView.js
+++ b/src/shared/handlers/ArticleRealtimeView.js
@@ -334,7 +334,6 @@ class ArticleRealtimeView extends React.Component {
       };
     });
 
-
     /* Who are the users */
     let [userTypeData, userTypeID, userTypeKeys] = dataFormatter.getPCTMetric('userTypes', 'Page Views')
     let timespan = this.props.timespan || "";


### PR DESCRIPTION
From this:
![screen shot 2016-02-29 at 10 12 47](https://cloud.githubusercontent.com/assets/1691942/13391563/0545cc0a-decd-11e5-9c06-33b61a033b52.png)

To this:
![screen shot 2016-02-29 at 10 12 31](https://cloud.githubusercontent.com/assets/1691942/13391565/06f277a6-decd-11e5-805e-2fa3a4a0435b.png)

Also looks better in mobile devices - the tooltips still display the full values e.g. 10,201
