### PR TITLE
Add sorting to the realtime last published chart

### DIFF
--- a/src/shared/handlers/ArticleRealtimeView.js
+++ b/src/shared/handlers/ArticleRealtimeView.js
@@ -180,7 +180,12 @@ class ArticleRealtimeView extends React.Component {
       }
     }
 
-    let publishedDates = this.props.lastPublishDate.slice().reverse().map((d, i) => {
+    let lastPublishDate = this.props.lastPublishDate;
+    lastPublishDate.sort(function(a,b) {
+      return a.key - b.key
+    });
+
+    let publishedDates = lastPublishDate.slice().map((d, i) => {
       return {
         value: d.key_as_string,
         text: (i) ? 'Republished' : 'Published'


### PR DESCRIPTION
Example here:
http://lantern.ft.com/realtime/articles/3dc894d2-de95-11e5-b67f-a61732c1d025/24h

| From this:   |      To this:      | 
|----------|:-------------:|
|  ![screen shot 2016-02-29 at 11 24 31](https://cloud.githubusercontent.com/assets/1691942/13393072/15fc0d48-ded7-11e5-8594-39fb3f5be41a.png)| ![screen shot 2016-02-29 at 11 24 22](https://cloud.githubusercontent.com/assets/1691942/13393081/1e1ed212-ded7-11e5-9ee4-789f2f1b961b.png) |