### PR TITLE
Check for existing timeData before attempting to set a property on it

### DIFF
--- a/src/shared/components/SectionWhen.js
+++ b/src/shared/components/SectionWhen.js
@@ -34,7 +34,7 @@ export default class SectionWhen extends React.Component {
 
     // Update the first data point to match the publish time
     // as the aggs are in hours not minutes
-    if(this.props.lastPublishDates.length > 0) {
+    if(this.props.lastPublishDates.length > 0 && timeData[0]) {
       timeData[0].category = this.props.lastPublishDates[0].key_as_string
     }
 


### PR DESCRIPTION
Fixes `/articles/f647702e-5c53-11e5-9846-de406ccb37f2/24/global/FT` throwing errors