### PR TITLE
Fixed not_analyzed for queries in Lantern

### DIFF
--- a/src/server/queries/articleComparatorQuery.js
+++ b/src/server/queries/articleComparatorQuery.js
@@ -16,8 +16,8 @@ export default function ArticleComparatorQuery(query){
 
   let comparatorTypes = {
     genre : {  genre: query.comparator  },
-    section : {  sections: query.comparator  },
-    topic : {  topics: query.comparator  },
+    section : {  sections_not_analyzed: query.comparator  },
+    topic : {  topics_not_analyzed: query.comparator  },
     author : {  authors: query.comparator  }
   }
 

--- a/test/queries/articleComparatorQuery.spec.js
+++ b/test/queries/articleComparatorQuery.spec.js
@@ -110,7 +110,7 @@ describe('Article Comparator Query', () => {
                 },
                 {
                   match: {
-                    sections: 'comparator'
+                    sections_not_analyzed: 'comparator'
                   }
                 }
               ],
@@ -176,7 +176,7 @@ describe('Article Comparator Query', () => {
                 },
                 {
                   match: {
-                    sections: 'comparator'
+                    sections_not_analyzed: 'comparator'
                   }
                 }
               ],
@@ -242,7 +242,7 @@ describe('Article Comparator Query', () => {
                 },
                 {
                   match: {
-                    sections: 'comparator'
+                    sections_not_analyzed: 'comparator'
                   }
                 }
               ],


### PR DESCRIPTION
- Changed topics and sections in comparator to be `topics_not_analyzed` and `sections_not_analyzed`
With the old system, if the section was 'Travel' the article was also pulling in 'Travel & Leisure', etc.
`x_not_analyzed` ensures that it only searches ES for the precise field.
- Fixed unit tests to use `sections_not_analyzed` instead of `sections`