### PR TITLE
hide comparator data when it's the FT on section and topic view headline stats

### DIFF
--- a/src/shared/handlers/SectionView.js
+++ b/src/shared/handlers/SectionView.js
@@ -71,6 +71,8 @@ class SectionView extends React.Component {
     let [socialData, socialID, socialKeys] = dataFormatter.getPCTMetric('socialReferrers', 'Views');
     let [internalData, internalID, internalKeys] = dataFormatter.getPCTMetric('internalReferrerTypes', 'Views');
 
+    const isFTComparator = this.props.params.comparator === 'FT';
+
     const headlineStats = {
       topicsCovered: {
         metricType: 'integer',
@@ -82,14 +84,14 @@ class SectionView extends React.Component {
         metricType: 'integer',
         label: 'Unique Visitors',
         size: 'large',
-        comparatorFormatName: 'uniqueVisitors',
+        comparatorFormatName: isFTComparator ? null : 'uniqueVisitors',
         toolTip: (<Text message='explanations.metric.uniqueVisitors' />)
       },
       articlePublishCount: {
         metricType: 'integer',
         label: 'Articles Published',
         size: 'large',
-        comparatorFormatName: 'articlePublishCount'
+        comparatorFormatName: isFTComparator ? null : 'articlePublishCount'
       }
     }
 

--- a/src/shared/handlers/TopicView.js
+++ b/src/shared/handlers/TopicView.js
@@ -61,19 +61,21 @@ class TopicView extends React.Component {
     let [socialData, socialID, socialKeys] = dataFormatter.getPCTMetric('socialReferrers', 'Views');
     let [internalData, internalID, internalKeys] = dataFormatter.getPCTMetric('internalReferrerTypes', 'Views');
 
-    let headlineStats = {
+    const isFTComparator = this.props.params.comparator === 'FT';
+
+    const headlineStats = {
       uniqueVisitors: {
         metricType: 'integer',
         label: 'Unique Visitors',
         size: 'large',
-        comparatorFormatName: 'uniqueVisitors',
+        comparatorFormatName: isFTComparator ? null : 'uniqueVisitors',
         toolTip: (<Text message='explanations.metric.uniqueVisitors' />)
       },
       articleCount: {
         metricType: 'integer',
         label: 'Articles Published',
         size: 'large',
-        comparatorFormatName: 'articleCount'
+        comparatorFormatName: isFTComparator ? null : 'articleCount'
       }
     }
 


### PR DESCRIPTION
[trello card](https://trello.com/c/XUtOObZQ)