### PR TITLE
Switch to use an article without quotes in the title

### DIFF
--- a/test/nightwatch/functional/article-element-confirm.js
+++ b/test/nightwatch/functional/article-element-confirm.js
@@ -28,12 +28,12 @@ module.exports = {
     browser
       .assert.attributeContains(nConcat.dataComponent(articlePage.sectionHeader.articleTitle), 'href', articlePage.exampleArticleLink,
       'href for article title is correct')
-      .assert.containsText(nConcat.dataComponent(articlePage.sectionHeader.articleTitle), "‘I wore a top hat while sleeping rough, then set up a top-hat business’",
-      "‘I wore a top hat while sleeping rough, then set up a top-hat business’")
-      .assert.containsText(nConcat.dataComponent(articlePage.sectionHeader.articleAuthor), 'Jeremy Taylor',
-      'Article author is "Jeremy Taylor"')
-      .assert.containsText(nConcat.dataComponent(articlePage.sectionHeader.articlePublished), 'February 26, 2016 11:22 am',
-      'Article was published "February 26, 2016 11:22 am"')
+      .assert.containsText(nConcat.dataComponent(articlePage.sectionHeader.articleTitle), "Google takes on Go grandmaster in AI test",
+      "Article title is correct")
+      .assert.containsText(nConcat.dataComponent(articlePage.sectionHeader.articleAuthor), 'Jung-a Song',
+      'Article author is correct')
+      .assert.containsText(nConcat.dataComponent(articlePage.sectionHeader.articlePublished), 'March 8, 2016 8:26 am',
+      'Article publish date is correct')
   },
 
   'Assert elements in Headline Stats Section' : function (browser) {

--- a/test/nightwatch/pages/article-page.js
+++ b/test/nightwatch/pages/article-page.js
@@ -2,9 +2,9 @@
 module.exports = {
 
   // Links
-  exampleArticleUrl : 'http://localhost:' + process.env.PORT + '/articles/ff767034-da82-11e5-98fd-06d75973fe09/48',
-  exampleArticleTitle: "Lantern - ‘I wore a top hat while sleeping rough, then set up a top-hat business’",
-  exampleArticleLink: 'http://www.ft.com/cms/s/0/ff767034-da82-11e5-98fd-06d75973fe09.html',
+  exampleArticleUrl : 'http://localhost:' + process.env.PORT + '/articles/07f006a6-e4f8-11e5-ac45-5c039e797d1c/48',
+  exampleArticleTitle: "Lantern - Google takes on Go grandmaster in AI test",
+  exampleArticleLink: 'http://www.ft.com/cms/s/0/07f006a6-e4f8-11e5-ac45-5c039e797d1c.html',
 
   // Modifier Section
   sectionModifier: {


### PR DESCRIPTION
Fixes inconsistency where historical data from redshift comes through without quotes and realtime comes through with quotes.

We can't (yet) fix the source data, so tweak the func test to not depend on non-deterministic article titles.