### PR TITLE
Fix catch statements on data-preloader routes

### DIFF
--- a/src/server/routers/dataPreloader-routes.js
+++ b/src/server/routers/dataPreloader-routes.js
@@ -248,8 +248,11 @@ function getSectionData(req, res){
       };
       return res;
     }).catch((error) => {
-      res.locals.data.AnalyticsStore = {
-        errorMessage: error.message
+      res.locals.data = {
+        AnalyticsStore : {
+          errorMessage : error.message,
+          error: error
+        }
       }
     })
 }
@@ -293,8 +296,11 @@ function getTopicData(req, res){
       };
       return res;
     }).catch((error) => {
-      res.locals.data.AnalyticsStore = {
-        errorMessage: error.message
+      res.locals.data = {
+        AnalyticsStore : {
+          errorMessage : error.message,
+          error: error
+        }
       }
     })
 
@@ -319,8 +325,11 @@ function getTopArticlesData(req, res) {
       };
       return res;
     }).catch((error) => {
-      res.locals.data.AnalyticsStore = {
-        errorMessage: error.message
+      res.locals.data = {
+        AnalyticsStore : {
+          errorMessage : error.message,
+          error: error
+        }
       }
     })
   }


### PR DESCRIPTION
ensure that we define `res.locals.data` when we catch errors on the data preloader

[trello card](https://trello.com/c/C2UluQGm)