### PR TITLE
update the query when changing date ranges

### DIFF
--- a/src/shared/handlers/HistoricalAnalyticsView.js
+++ b/src/shared/handlers/HistoricalAnalyticsView.js
@@ -134,6 +134,11 @@ class HistoricalAnalyticsView extends React.Component {
     let dateTo = moment(e.endDate, 'milliseconds').toISOString();
     let comparatorPath;
 
+    AnalyticsActions.updateQuery({
+      dateFrom : dateFrom,
+      dateTo : dateTo
+    });
+
     switch (this.props.route.analyticsView) {
       case VIEW_TYPE_ARTICLE:
         comparatorPath = (params.comparator) ? `/${params.comparatorType}/${params.comparator}` : '';


### PR DESCRIPTION
We were relying on pushing onto history for changing date ranges, but that was only working the first time (since the changes were happening on the url's query)

We now ensure the query is updated using the AnalyticsActions `updateQuery` action