### PR TITLE
Update New Relic instrumentation

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,6 +5,9 @@
   },
   "env":{
     "NODE_ENV": "production",
+    "NEW_RELIC_APP_NAME" : {
+      "value": "Lantern - review"
+    },
     "USE_MEMORY_STORE": "true",
     "HEROKU_APP_NAME": {
       "required": true

--- a/newrelic.js
+++ b/newrelic.js
@@ -8,7 +8,8 @@ exports.config = {
   /**
    * Array of application names.
    */
-  app_name: ['Lantern - New Relic'],
+  app_name: ['Lantern - local-development'],
+  capture_params: true,
   /**
    * Your New Relic license key.
    */

--- a/src/server/routers/api-routes.js
+++ b/src/server/routers/api-routes.js
@@ -11,6 +11,7 @@ import TopicDataFormatter from '../formatters/Topics';
 import TopArticlesFormatter from '../formatters/TopArticles';
 import getTitleForUrl from '../utils/getTitleFromUrl';
 import moment from 'moment';
+import newrelic from 'newrelic';
 
 const UUID_REGEX = '[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}';
 
@@ -18,6 +19,7 @@ let router = express.Router();
 router.use(bodyParser.json());
 
 router.get('/queries', function(req, res) {
+  newrelic.setTransactionName('Api/Queries');
   req.pipe(esClient.queryStream).pipe(res);
 });
 
@@ -37,6 +39,7 @@ function decode(uri){
 }
 
 function getCategoryData(req, res, next) {
+  newrelic.setTransactionName('Api/Archive/Articles');
   const query = {
     uuid: decode(req.params.uuid),
     dateFrom: req.body.dateFrom,
@@ -76,6 +79,7 @@ function getCategoryData(req, res, next) {
 }
 
 function getRealtimeArticleData(req, res, next) {
+  newrelic.setTransactionName('Api/Live/Articles');
   const query = {
     uuid: decode(req.params.uuid),
     timespan: req.query.timespan
@@ -91,6 +95,7 @@ function getRealtimeArticleData(req, res, next) {
 }
 
 function getRealtimeSectionData(req, res, next) {
+  newrelic.setTransactionName('Api/Live/Sections');
   const query = {
     section: decode(req.params.section),
     timespan: req.query.timespan
@@ -106,6 +111,7 @@ function getRealtimeSectionData(req, res, next) {
 }
 
 function getSectionData(req, res, next) {
+  newrelic.setTransactionName('Api/Archive/Sections');
   const query = {
     section: decode(req.params.section),
     dateFrom: req.body.dateFrom,
@@ -126,6 +132,7 @@ function getSectionData(req, res, next) {
 
 import RealtimeArticleListFormatter from '../formatters/RealtimeArticleListFormatter';
 function getRealtimeArticleList(req, res, next) {
+  newrelic.setTransactionName('Api/Live/ArticleList');
   const query = {
     type: req.params.type,
     value: decode(req.params.value),
@@ -144,6 +151,7 @@ function getRealtimeArticleList(req, res, next) {
 
 import ArticleListFormatter from '../formatters/ArticleListFormatter';
 function getArticleList(req, res, next) {
+  newrelic.setTransactionName('Api/Archive/ArticleList');
   const query = {
     type: req.params.type,
     value: decode(req.params.value),
@@ -159,6 +167,7 @@ function getArticleList(req, res, next) {
 }
 
 function getTopicData(req, res, next) {
+  newrelic.setTransactionName('Api/Archive/Topics');
   const query = {
     topic: decode(req.params.topic),
     dateFrom: req.body.dateFrom,
@@ -178,6 +187,7 @@ function getTopicData(req, res, next) {
 }
 
 function search(req, res, next) {
+  newrelic.setTransactionName('Api/Search');
   const query = req.params.query;
   const from = 0 || req.query.from;
 
@@ -191,6 +201,7 @@ function search(req, res, next) {
 }
 
 function getTopArticlesData(req, res, next) {
+  newrelic.setTransactionName('Api/TopArticles');
   const query = {
     dateFrom: moment().subtract(1, 'days').startOf('day').toISOString(),
     dateTo: moment().subtract(1, 'days').endOf('day').toISOString()

--- a/src/server/routers/dataPreloader-routes.js
+++ b/src/server/routers/dataPreloader-routes.js
@@ -2,7 +2,7 @@
 import express from 'express';
 import moment from 'moment';
 import dataApiUtils from '../../shared/utils/DataAPIUtils';
-
+import newrelic from 'newrelic';
 let router = express.Router();
 let apiKey = process.env.LANTERN_API_KEY;
 const UUID_REGEX = '[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}';
@@ -13,6 +13,7 @@ function decode(uri){
 }
 
 router.get(`/realtime/articles/:uuid(${UUID_REGEX})`, (req, res, next) => {
+  newrelic.setTransactionName('Preloader/Live/Articles');
   return getArticleRealtimeData(req, res)
     .then(() => next())
     .catch((err) => {
@@ -22,6 +23,7 @@ router.get(`/realtime/articles/:uuid(${UUID_REGEX})`, (req, res, next) => {
 });
 
 router.get(`/realtime/articles/:uuid(${UUID_REGEX})/:timespan`, (req, res, next) => {
+  newrelic.setTransactionName('Preloader/Live/Articles');
   return getArticleRealtimeData(req, res)
     .then(() => next())
     .catch((err) => {
@@ -31,6 +33,7 @@ router.get(`/realtime/articles/:uuid(${UUID_REGEX})/:timespan`, (req, res, next)
 });
 
 router.get(`/articles/:uuid(${UUID_REGEX})/:timespan`, (req, res, next) => {
+  newrelic.setTransactionName('Preloader/Archive/Articles');
   return getArticleData(req, res)
     .then(() => next())
     .catch((err) => {
@@ -40,6 +43,7 @@ router.get(`/articles/:uuid(${UUID_REGEX})/:timespan`, (req, res, next) => {
 });
 
 router.get(`/articles/:uuid(${UUID_REGEX})/:timespan/:comparatorType(${COMPTYPE_REGEX})/:comparator`, (req, res, next) => {
+  newrelic.setTransactionName('Preloader/Archive/Articles/WithComparator');
   return getArticleData(req, res)
     .then(() => next())
     .catch((err) => {
@@ -49,6 +53,7 @@ router.get(`/articles/:uuid(${UUID_REGEX})/:timespan/:comparatorType(${COMPTYPE_
 });
 
 router.get(`/sections/:section/:timespan`, (req, res, next) => {
+  newrelic.setTransactionName('Preloader/Archive/Section');
   return getSectionData(req, res)
     .then(() => next())
     .catch((err) => {
@@ -58,6 +63,7 @@ router.get(`/sections/:section/:timespan`, (req, res, next) => {
 });
 
 router.get(`/sections/:section/:timespan/:comparatorType(${COMPTYPE_REGEX})/:comparator`, (req, res, next) => {
+  newrelic.setTransactionName('Preloader/Archive/Section/WithComparator');
   return getSectionData(req, res)
     .then(() => next())
     .catch((err) => {
@@ -67,6 +73,7 @@ router.get(`/sections/:section/:timespan/:comparatorType(${COMPTYPE_REGEX})/:com
 });
 
 router.get(`/topics/:topic/:timespan`, (req, res, next) => {
+  newrelic.setTransactionName('Preloader/Archive/Topic');
   return getTopicData(req, res)
     .then(() => {next()})
     .catch((err) => {
@@ -76,6 +83,7 @@ router.get(`/topics/:topic/:timespan`, (req, res, next) => {
 });
 
 router.get(`/topics/:topic/:timespan/:comparatorType(${COMPTYPE_REGEX})/:comparator`, (req, res, next) => {
+  newrelic.setTransactionName('Preloader/Archive/Topic/WithComparator');
   return getTopicData(req, res)
     .then(() => next())
     .catch((err) => {
@@ -85,6 +93,7 @@ router.get(`/topics/:topic/:timespan/:comparatorType(${COMPTYPE_REGEX})/:compara
 });
 
 router.get(`/thehighlights`, (req, res, next) => {
+  newrelic.setTransactionName('Preloader/Highlights');
   return getTopArticlesData(req, res)
     .then(() => next())
     .catch((err) => {

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -1,8 +1,6 @@
 let config = require("../shared/config");
 
-if (config.newrelic) {
-  require('newrelic');
-}
+let newrelic = require('newrelic');
 
 let express = require("express");
 let exphbs = require("express-handlebars");
@@ -137,6 +135,8 @@ function renderRoute(route, req, res) {
     } else if (redirectLocation) {
       res.redirect(302, redirectLocation.pathname + redirectLocation.search);
     } else if (renderProps) {
+      const matchedRoute = renderProps.routes.map((d) => d.path).join('/')
+      newrelic.setTransactionName('Page Render ' + matchedRoute);
       let content = ReactDOMServer.renderToString(<RoutingContext {...renderProps} />);
       iso.add(content, alt.flush());
       const templateProps = {

--- a/src/shared/config/default.js
+++ b/src/shared/config/default.js
@@ -5,7 +5,6 @@ let config = {
   baseUrl: 'http://localhost:' + port,
   jsUrl: "//localhost:8082",
   gaTrackingID: 'UA-60698836-4',
-  newrelic: false,
   garbageCollectionInterval: 60000,
   features : {
     'home:recentArticles' : true,

--- a/src/shared/config/production.js
+++ b/src/shared/config/production.js
@@ -1,5 +1,4 @@
 export default {
-  newrelic: true,
   jsUrl:   "",
   features : {
     'home:recentArticles' : false,


### PR DESCRIPTION
I've added more human-readable names to the routes displayed on rewrelic, as well as websocket instrumentations.

This also means our production app will now be called 'Lantern - New Relic' (as per current status), whereas review apps will all be clumped into 'Lantern - Review', and stuff from our local copy will be called 'Lantern - local-development'

[trello card](https://trello.com/c/sDbF7dbx)