### PR TITLE
add SVG Pathseg polyfill to stop getItem errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "object-assign": "^4.0.1",
     "passport": "^0.3.0",
     "passport-google-oauth2": "^0.1.6",
+    "pathseg": "^1.0.2",
     "raven": "^0.8.1",
     "raven-js": "^1.1.20",
     "react": "^0.14.3",

--- a/src/client/entry.js
+++ b/src/client/entry.js
@@ -1,3 +1,7 @@
+// polyfill for deprecated SVG PathSeg apis
+// remove when we update to c3 v0.4.11
+// https://github.com/masayuki0812/c3/issues/1566
+require('pathseg');
 import React from "react";
 import ReactDOM from "react-dom";
 import Iso from "iso";
@@ -5,7 +9,6 @@ import alt from "../shared/alt";
 import Router from "react-router";
 import routes from "../shared/routers/routes";
 import createBrowserHistory from "history/lib/createBrowserHistory";
-
 import "./styles/app"
 
 let history = createBrowserHistory();


### PR DESCRIPTION
chrome 48 removed the PathSeg api, which c3 requires. By adding this polyfill we stop errors from happening:

[Sentry Errors](https://app.getsentry.com/ft/lantern-production/issues/117270571/)

[trello card](https://trello.com/c/0EKscz3R/765-sentry-errors-getitem-error-when-clicking-on-charts)