### PR TITLE
fix ReferenceError: type is not defined

### DIFF
--- a/src/shared/utils/DataAPIUtils.js
+++ b/src/shared/utils/DataAPIUtils.js
@@ -186,7 +186,7 @@ let DataAPI = {
           .set('Accept', 'application/json')
           .end((err, res) => {
             if (err) {
-              err.name = errorName(type, err);
+              err.name = errorName('Status', err);
               if (res && res.body) {
                 err.message = res.body.message;
               }


### PR DESCRIPTION
we were trying to create an ErrorName with an undefined variable, which was causing errors on `getStatus`.

I've replaced it to be just the string `'Status'` instead of the variable `type` which was not defined.

This fixes [this sentry issue](https://app.getsentry.com/ft/lantern-production/issues/110552501/)

[Trello Card](https://trello.com/c/slcQGgzH)