### PR TITLE
Stop the sentry Intl error

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "history": "~1.17.0",
     "html-entities": "^1.2.0",
     "http-aws-es": "^1.1.2",
-    "intl": "^1.0.1",
+    "intl": "^1.1.0",
     "iso": "^4.2.0",
     "istanbul": "^0.3.22",
     "jquery": "^2.1.4",

--- a/src/shared/components/Text.js
+++ b/src/shared/components/Text.js
@@ -10,6 +10,12 @@ var intlData = {
   messages: assign({}, ComponentStrings, HandlerStrings, ExplanationStrings)
 };
 
+if (global.Intl == null) {
+  var IntlPolyfill = require('intl');
+  Intl.NumberFormat = IntlPolyfill.NumberFormat;
+  Intl.DateTimeFormat = IntlPolyfill.DateTimeFormat;
+}
+
 // This older style of class was used to accomadate the React Intl Mixin
 // When React Intl is updated for full ES6 this can be updated
 var Text = React.createClass({


### PR DESCRIPTION
Safari doesn't have its own Intl but Chome does which is why this was missed